### PR TITLE
docs: clarify timeout parameter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For usage examples, see the [examples folder](https://github.com/MountainGod2/cb
 from cb_events import ClientConfig
 
 config = ClientConfig(
-    timeout=10,                   # Request timeout (seconds)
+    timeout=10,                   # Server long-poll timeout (seconds)
     use_testbed=False,            # Use testbed endpoint with test tokens
     strict_validation=False,      # False skips & logs invalid events; True raises.
     retry_attempts=8,             # Total attempts (initial + retries)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,9 +55,6 @@ html_copy_source = False
 html_last_updated_fmt = "%b %d, %Y"
 
 html_theme_options: dict[str, str | dict[str, str] | bool] = {
-    "source_repository": "https://github.com/MountainGod2/cb-events",
-    "source_branch": "main",
-    "source_directory": "docs/",
     "light_css_variables": {
         "color-brand-primary": "#7C4DFF",
         "color-brand-content": "#7C4DFF",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,7 +9,7 @@ Client Configuration
    from cb_events import EventClient, ClientConfig
 
    config = ClientConfig(
-       timeout=10,                   # Request timeout (seconds)
+       timeout=10,                   # Server long-poll timeout (seconds)
        use_testbed=False,            # Use testbed endpoint
        strict_validation=False,      # Raise on invalid events vs. skip
        retry_attempts=8,             # Total attempts (initial + retries)
@@ -24,10 +24,13 @@ Client Configuration
 Timeout Settings
 ----------------
 
+The ``timeout`` parameter controls the maximum time (in seconds) the
+Chaturbate server will wait before sending back a response.
+
 .. code-block:: python
 
-   config = ClientConfig(timeout=5)   # Fast-fail
-   config = ClientConfig(timeout=30)  # Unreliable networks
+   config = ClientConfig(timeout=5)   # More frequent polls
+   config = ClientConfig(timeout=30)  # Server holds connection longer
 
 Default: 10 seconds
 

--- a/src/cb_events/client.py
+++ b/src/cb_events/client.py
@@ -279,7 +279,7 @@ class EventClient:
         username: Chaturbate username for the event feed.
         token: API token for authentication.
         config: Client configuration instance.
-        timeout: Request timeout in seconds.
+        timeout: Server long-poll timeout in seconds.
         base_url: API endpoint base URL.
         session: Active HTTP session (None until context entry).
 

--- a/src/cb_events/config.py
+++ b/src/cb_events/config.py
@@ -53,7 +53,7 @@ class ClientConfig(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     timeout: int = Field(default=10, gt=0)
-    """Request timeout in seconds."""
+    """Server long-poll timeout in seconds."""
 
     use_testbed: bool = False
     """Use the testbed API instead of production."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the timeout configuration parameter denotes the server long-poll wait time in seconds (not a generic request timeout); updated examples, inline comments, and docstrings across README, configuration guide, and client docs for consistency.
  * Removed repository/branch/directory metadata entries from the documentation build theme configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->