### PR TITLE
feat: convert next_url_allowed_hosts to tuple and reorganize constants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: install sync format check fix type-check lint test test-cov test-all pre-commit build dev-setup ci clean docs docs-clean docs-serve docs-linkcheck trivy help all
+.PHONY: install sync format check fix type-check lint test test-cov check-all pre-commit build dev-setup ci clean docs docs-clean docs-serve docs-linkcheck trivy help all
+
+PYTHON_VERSIONS ?= 3.10 3.11 3.12 3.13 3.14
 
 all: format fix lint test
 
@@ -39,8 +41,6 @@ trivy:
 	trivy fs --severity HIGH,CRITICAL --format table .
 	trivy config --severity HIGH,CRITICAL --format table .
 
-PYTHON_VERSIONS ?= 3.10 3.11 3.12 3.13 3.14
-
 test:
 	uv run pytest
 
@@ -50,7 +50,7 @@ test-cov:
 test-e2e:
 	uv run pytest -m e2e --no-cov
 
-test-all:
+check-all:
 	@for version in $(PYTHON_VERSIONS); do \
 		uv run --python $$version --group test pytest -q --no-cov || exit 1; \
 		uv run --python $$version --group lint pyrefly check || exit 1; \
@@ -103,9 +103,10 @@ help:
 	@echo "Development:"
 	@echo "  format     check     fix       type-check"
 	@echo "  lint       bandit    trivy     pre-commit"
+	@echo "  check-all"
 	@echo ""
 	@echo "Testing:"
-	@echo "  test       test-cov  test-all  test-e2e"
+	@echo "  test       test-cov  test-e2e"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  docs       docs-serve docs-linkcheck"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install sync format check fix type-check lint test test-cov pre-commit build dev-setup ci clean docs docs-clean docs-serve docs-linkcheck trivy help all
+.PHONY: install sync format check fix type-check lint test test-cov test-all pre-commit build dev-setup ci clean docs docs-clean docs-serve docs-linkcheck trivy help all
 
 all: format fix lint test
 
@@ -8,6 +8,7 @@ install:
 sync: install
 
 dev-setup: install
+	uv python install $(PYTHON_VERSIONS)
 	uv run pre-commit install
 
 format:
@@ -38,6 +39,8 @@ trivy:
 	trivy fs --severity HIGH,CRITICAL --format table .
 	trivy config --severity HIGH,CRITICAL --format table .
 
+PYTHON_VERSIONS ?= 3.10 3.11 3.12 3.13 3.14
+
 test:
 	uv run pytest
 
@@ -46,6 +49,14 @@ test-cov:
 
 test-e2e:
 	uv run pytest -m e2e --no-cov
+
+test-all:
+	@for version in $(PYTHON_VERSIONS); do \
+		uv run --python $$version --group test pytest -q --no-cov || exit 1; \
+		uv run --python $$version --group lint pyrefly check || exit 1; \
+		uv run --python $$version --group lint pyright || exit 1; \
+		uv run --python $$version --group lint ty check src || exit 1; \
+	done
 
 pre-commit:
 	uv run pre-commit run --all-files
@@ -94,7 +105,7 @@ help:
 	@echo "  lint       bandit    trivy     pre-commit"
 	@echo ""
 	@echo "Testing:"
-	@echo "  test       test-cov  test-e2e"
+	@echo "  test       test-cov  test-all  test-e2e"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  docs       docs-serve docs-linkcheck"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ config = ClientConfig(
     retry_backoff=1.0,            # Initial backoff (seconds)
     retry_factor=2.0,             # Backoff multiplier
     retry_max_delay=30.0,         # Max retry delay (seconds)
-    next_url_allowed_hosts=None,  # None = API host only; list adds extra hosts
+    next_url_allowed_hosts=None,  # None = API host only; tuple adds extra hosts
 )
 
 client = EventClient(username, token, config=config)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,7 +16,7 @@ Client Configuration
        retry_backoff=1.0,            # Initial backoff (seconds)
        retry_factor=2.0,             # Backoff multiplier
        retry_max_delay=30.0,         # Max retry delay (seconds)
-       next_url_allowed_hosts=None,  # List of allowed hostnames for next_url
+       next_url_allowed_hosts=None,  # Tuple of allowed hostnames for next_url
    )
 
    client = EventClient(username, token, config=config)
@@ -112,12 +112,12 @@ Allowed Hosts
 -------------
 
 ``next_url_allowed_hosts=None`` restricts ``nextUrl`` to the configured API host
-only. Pass a list to permit extra hostnames:
+only. Pass a tuple to permit extra hostnames:
 
 .. code-block:: python
 
    config = ClientConfig(
-       next_url_allowed_hosts=["eventsapi.chaturbate.com", "events.testbed.cb.dev"]
+       next_url_allowed_hosts=("eventsapi.chaturbate.com", "events.testbed.cb.dev")
    )
 
 .. warning::

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,7 +123,7 @@ only. Pass a tuple to permit extra hostnames:
 .. warning::
 
    ``None`` does **not** mean allow any host — it means the API host only.
-   An explicit list extends that set; it does not replace it.
+   An explicit tuple extends that set; it does not replace it.
 
 Logging
 -------

--- a/src/cb_events/client.py
+++ b/src/cb_events/client.py
@@ -12,7 +12,7 @@ import sys
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
 from http import HTTPStatus
 from types import TracebackType
-from typing import Final, NoReturn, cast
+from typing import Final, NoReturn
 from urllib.parse import quote, urljoin, urlparse
 
 import stamina
@@ -22,7 +22,12 @@ from aiolimiter import AsyncLimiter
 from pydantic import ValidationError
 
 from .config import ClientConfig
-from .exceptions import AuthError, EventsError, build_http_error
+from .exceptions import (
+    AUTH_ERROR_STATUS_CODES,
+    AuthError,
+    EventsError,
+    build_http_error,
+)
 from .models import Event
 
 if sys.version_info >= (3, 11):
@@ -52,16 +57,17 @@ TOKEN_VISIBLE_CHARS: Final[int] = 0
 TRUNCATE_LENGTH: Final[int] = 200
 """Maximum number of characters of response text shown in logs."""
 
-AUTH_ERRORS: Final[frozenset[int]] = frozenset({
-    HTTPStatus.UNAUTHORIZED.value,
-    HTTPStatus.FORBIDDEN.value,
-})
-"""HTTP status codes treated as authentication failures."""
-
 CF_ORIGIN_DOWN: Final[int] = 521
+"""Cloudflare status code indicating the origin server is down."""
+
 CF_CONNECTION_TIMEOUT: Final[int] = 522
+"""Cloudflare status code indicating a connection timeout to the origin."""
+
 CF_ORIGIN_UNREACHABLE: Final[int] = 523
+"""Cloudflare status code indicating the origin is unreachable."""
+
 CF_TIMEOUT_OCCURRED: Final[int] = 524
+"""Cloudflare status code indicating a timeout occurred."""
 
 RETRY_STATUS_CODES: Final[frozenset[int]] = frozenset({
     HTTPStatus.INTERNAL_SERVER_ERROR.value,
@@ -172,7 +178,7 @@ def _normalize_host_entry(candidate: object) -> str | None:
 
 
 def _build_allowed_hosts(
-    base_url: str, extra_hosts: Sequence[str] | None
+    base_url: str, extra_hosts: tuple[str, ...] | None
 ) -> set[str]:
     """Build the set of permitted hostnames for nextUrl redirection.
 
@@ -203,13 +209,9 @@ def _log_validation_error(
         item: Raw object that failed validation.
         exc: The ValidationError raised during parsing.
     """
-    mapping_item = None
-    if isinstance(item, Mapping):
-        mapping_item = cast("Mapping[str, object]", item)
-
     event_id = (
-        mapping_item.get("id", "<unknown>")
-        if mapping_item is not None
+        item.get("id", "<unknown>")  # ty: ignore[no-matching-overload]
+        if isinstance(item, Mapping)
         else "<unknown>"
     )
     fields: set[str] = set()
@@ -235,12 +237,11 @@ def _parse_events(raw: Sequence[object], *, strict: bool) -> list[Event]:
     Returns:
         List of validated Event instances.
     """
-    events = []
-    for item in raw:
-        event = _parse_event(item, strict=strict)
-        if event is not None:
-            events.append(event)
-    return events
+    return [
+        event
+        for item in raw
+        if (event := _parse_event(item, strict=strict)) is not None
+    ]
 
 
 def _parse_event(item: object, *, strict: bool) -> Event | None:
@@ -279,7 +280,6 @@ class EventClient:
         username: Chaturbate username for the event feed.
         token: API token for authentication.
         config: Client configuration instance.
-        timeout: Server long-poll timeout in seconds.
         base_url: API endpoint base URL.
         session: Active HTTP session (None until context entry).
 
@@ -612,7 +612,7 @@ class EventClient:
             EventsError: For other non-200 responses or when response format is
                 invalid. Includes HTTP metadata when available.
         """  # noqa: DOC501, DOC502
-        if status in AUTH_ERRORS:
+        if status in AUTH_ERROR_STATUS_CODES:
             logger.warning(
                 "Authentication failed for user %s (HTTP %d)",
                 self.username,

--- a/src/cb_events/config.py
+++ b/src/cb_events/config.py
@@ -73,7 +73,7 @@ class ClientConfig(BaseModel):
     retry_max_delay: float = Field(default=30.0, ge=0)
     """Maximum delay between retries in seconds."""
 
-    next_url_allowed_hosts: list[str] | None = None
+    next_url_allowed_hosts: tuple[str, ...] | None = None
     """Hosts permitted for nextUrl responses; defaults to API host only."""
 
     @model_validator(mode="after")

--- a/src/cb_events/exceptions.py
+++ b/src/cb_events/exceptions.py
@@ -26,26 +26,19 @@ Example:
 
 from typing import Final
 
-_RESPONSE_TEXT_LIMIT: Final[int] = 200
-"""Maximum characters stored in response_text to limit PII exposure in logs."""
-
 AUTH_ERROR_STATUS_CODES: Final[frozenset[int]] = frozenset({401, 403})
 """HTTP status codes indicating authentication failures."""
 
-RATE_LIMIT_STATUS_CODE: Final[int] = 429
-"""HTTP status code for rate limiting."""
+_RESPONSE_TEXT_LIMIT: Final[int] = 200
+"""Maximum characters stored in response_text to limit PII exposure in logs."""
 
-CLIENT_ERROR_MIN_STATUS_CODE: Final[int] = 400
-"""Lower bound for HTTP client error status codes."""
+_RATE_LIMIT_STATUS_CODE: Final[int] = 429
+"""HTTP status code indicating rate-limiting failures."""
+_CLIENT_ERROR_RANGE: Final[tuple[int, int]] = (400, 499)
+"""Range of HTTP status codes indicating client request errors."""
 
-CLIENT_ERROR_MAX_STATUS_CODE: Final[int] = 499
-"""Upper bound for HTTP client error status codes."""
-
-SERVER_ERROR_MIN_STATUS_CODE: Final[int] = 500
-"""Lower bound for HTTP server error status codes."""
-
-SERVER_ERROR_MAX_STATUS_CODE: Final[int] = 599
-"""Upper bound for HTTP server error status codes."""
+_SERVER_ERROR_RANGE: Final[tuple[int, int]] = (500, 599)
+"""Range of HTTP status codes indicating server errors."""
 
 
 class EventsError(Exception):
@@ -179,35 +172,24 @@ def build_http_error(
             status_code=status_code,
             response_text=response_text,
         )
-    if status_code == RATE_LIMIT_STATUS_CODE:
+    if status_code == _RATE_LIMIT_STATUS_CODE:
         return RateLimitError(
             message,
             status_code=status_code,
             response_text=response_text,
         )
-
-    if (
-        CLIENT_ERROR_MIN_STATUS_CODE
-        <= status_code
-        <= CLIENT_ERROR_MAX_STATUS_CODE
-    ):
+    if _CLIENT_ERROR_RANGE[0] <= status_code <= _CLIENT_ERROR_RANGE[1]:
         return ClientRequestError(
             message,
             status_code=status_code,
             response_text=response_text,
         )
-
-    if (
-        SERVER_ERROR_MIN_STATUS_CODE
-        <= status_code
-        <= SERVER_ERROR_MAX_STATUS_CODE
-    ):
+    if _SERVER_ERROR_RANGE[0] <= status_code <= _SERVER_ERROR_RANGE[1]:
         return ServerError(
             message,
             status_code=status_code,
             response_text=response_text,
         )
-
     return HttpStatusError(
         message,
         status_code=status_code,

--- a/src/cb_events/exceptions.py
+++ b/src/cb_events/exceptions.py
@@ -178,13 +178,15 @@ def build_http_error(
             status_code=status_code,
             response_text=response_text,
         )
-    if _CLIENT_ERROR_RANGE[0] <= status_code <= _CLIENT_ERROR_RANGE[1]:
+    client_min, client_max = _CLIENT_ERROR_RANGE
+    server_min, server_max = _SERVER_ERROR_RANGE
+    if client_min <= status_code <= client_max:
         return ClientRequestError(
             message,
             status_code=status_code,
             response_text=response_text,
         )
-    if _SERVER_ERROR_RANGE[0] <= status_code <= _SERVER_ERROR_RANGE[1]:
+    if server_min <= status_code <= server_max:
         return ServerError(
             message,
             status_code=status_code,

--- a/src/cb_events/router.py
+++ b/src/cb_events/router.py
@@ -25,7 +25,6 @@ Example:
 
 import logging
 from collections.abc import Awaitable, Callable
-from functools import partial
 from inspect import iscoroutinefunction
 from typing import TypeAlias, cast
 
@@ -55,7 +54,7 @@ async def _dispatch_handler(handler: HandlerFunc, event: Event) -> None:
             "Handler %s failed for event %s (type: %s)",
             _handler_name(handler),
             event.id,
-            event.type.value,
+            event.type,
         )
 
 
@@ -63,19 +62,13 @@ def _is_async_callable(func: object) -> bool:
     """Return whether func produces an awaitable when invoked once."""
     if iscoroutinefunction(func):
         return True
-
     if callable(func):
-        try:
-            call_method = type(func).__call__
-        except AttributeError:
-            call_method = None
+        call_method = getattr(type(func), "__call__", None)  # noqa: B004
         if call_method and iscoroutinefunction(call_method):
             return True
-
     underlying = getattr(func, "func", None)
     if callable(underlying) and underlying is not func:
         return _is_async_callable(underlying)
-
     return False
 
 
@@ -89,10 +82,6 @@ def _handler_name(handler: object) -> str:
         name = getattr(current, "__name__", None)
         if name:
             return name
-
-        if isinstance(current, partial):
-            current = current.func
-            continue
 
         wrapped = getattr(current, "__wrapped__", None)
         if callable(wrapped) and wrapped is not current:
@@ -210,7 +199,7 @@ class Router:
 
         logger.debug(
             "Dispatching %s event %s to %d handlers",
-            event.type.value,
+            event.type,
             event.id,
             len(handlers),
         )

--- a/tests/client/test_core_client.py
+++ b/tests/client/test_core_client.py
@@ -64,6 +64,7 @@ def test_mask_token_various_lengths() -> None:
     """
     token = "abcd1234"
     assert _mask_token(token, visible=20) == "*" * len(token)
+    assert _mask_token(token, visible=4) == "****1234"
     assert _mask_token(token, visible=0) == "*" * len(token)
     masked = _mask_token(token)
     assert masked == "*" * len(token)

--- a/tests/client/test_core_client.py
+++ b/tests/client/test_core_client.py
@@ -7,7 +7,6 @@ from pydantic import ValidationError
 
 from cb_events import ClientConfig, EventClient
 from cb_events.client import (
-    TOKEN_VISIBLE_CHARS,
     _mask_token,
     _mask_url,
     _parse_events,
@@ -23,7 +22,6 @@ def test_token_masking_in_repr() -> None:
 
     assert full_token not in repr_str
     assert "*" * len(full_token) in repr_str
-    assert TOKEN_VISIBLE_CHARS == 0
 
 
 @pytest.mark.parametrize(
@@ -44,11 +42,7 @@ def test_reject_invalid_credentials(
 
 
 def test_mask_url_replaces_raw_and_encoded_token() -> None:
-    """_mask_url should mask both plain and percent-encoded tokens in URLs.
-
-    When TOKEN_VISIBLE_CHARS == 0 the token is fully redacted and no trailing
-    characters are preserved in the masked output.
-    """
+    """_mask_url should mask both plain and percent-encoded tokens in URLs."""
     token = "super_secret_token_1234"
     encoded = quote(token, safe="")
     url = (
@@ -60,7 +54,6 @@ def test_mask_url_replaces_raw_and_encoded_token() -> None:
 
     assert token not in masked
     assert encoded not in masked
-    assert TOKEN_VISIBLE_CHARS == 0
 
 
 def test_mask_token_various_lengths() -> None:
@@ -74,7 +67,6 @@ def test_mask_token_various_lengths() -> None:
     assert _mask_token(token, visible=0) == "*" * len(token)
     masked = _mask_token(token)
     assert masked == "*" * len(token)
-    assert TOKEN_VISIBLE_CHARS == 0
 
 
 def test_parse_events_strict_and_lenient(
@@ -129,4 +121,3 @@ def test_eventclient_build_url_and_repr() -> None:
     r = repr(client)
     assert token not in r
     assert "*" * len(token) in r
-    assert TOKEN_VISIBLE_CHARS == 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Configuration parameter next_url_allowed_hosts now expects a tuple instead of a list.

* **Documentation**
  * Clarified configuration docs and examples to reflect the tuple expectation for next_url_allowed_hosts.

* **Chores**
  * Development setup extended to install multiple Python versions (3.10–3.14) and a new check-all command runs test and static/type checks across those versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->