### PR TITLE
chore(ci): update pypa/gh-action-pypi-publish to v1.14.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -142,7 +142,8 @@
       "labels": ["dependencies", "ci"],
       "automerge": true,
       "autoApprove": true,
-      "semanticCommitScope": "ci"
+      "semanticCommitScope": "ci",
+      "versioning": "semver"
     },
     {
       "description": "Dockerfile updates",

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -420,7 +420,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist
           print-hash: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow configuration to enhance consistency and reliability of version management and package publishing processes.
  * Refreshed infrastructure tooling references to latest stable versions for improved stability of automated build and deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->