### PR TITLE
fix(client): enforce HTTPS scheme for nextUrl validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
     hooks:
       - id: pip-audit
         name: pip audit security scan
-        entry: uv run --group=security pip-audit --local --ignore-vuln CVE-2026-3219
+        entry: uv run --group=security pip-audit --local
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ zizmor:
 	uv run zizmor --format=sarif . > zizmor.sarif
 
 pip-audit:
-	uv run --group=security pip-audit --local --ignore-vuln CVE-2026-3219
+	uv run --group=security pip-audit --local
 
 trivy:
 	@command -v trivy >/dev/null 2>&1 || { \

--- a/src/cb_events/client.py
+++ b/src/cb_events/client.py
@@ -679,13 +679,13 @@ class EventClient:
         absolute, parsed = self._resolve_absolute_url(stripped)
 
         scheme = parsed.scheme
-        if scheme not in {"http", "https"}:
+        if scheme != "https":
             logger.error(
                 "Received nextUrl with unsupported scheme %s for user %s",
                 scheme or "<missing>",
                 self.username,
             )
-            msg = "Invalid nextUrl scheme; only http/https are allowed."
+            msg = "Invalid nextUrl scheme; only https is allowed."
             raise EventsError(msg, response_text=response_text)
 
         hostname = parsed.hostname

--- a/tests/client/test_polling.py
+++ b/tests/client/test_polling.py
@@ -306,6 +306,10 @@ async def test_relative_next_url_resolved_to_absolute(
         ("   ", r"Invalid API response: 'nextUrl' must be"),
         ({}, r"Invalid API response: 'nextUrl' must be"),
         ("javascript:alert(1)", r"Invalid nextUrl scheme"),
+        (
+            "http://events.testbed.cb.dev/events/test_user/test_token/",
+            r"Invalid nextUrl scheme",
+        ),
         ("https:///nohost", r"Invalid nextUrl host"),
         ("//evil.com/path", r"Invalid nextUrl host"),
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened URL scheme validation to enforce HTTPS-only URLs, rejecting HTTP and other schemes that were previously allowed.

* **Tests**
  * Added test coverage for invalid HTTP URL handling to verify the stricter validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->