### PR TITLE
feat!: switch to URL-based Events API configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-# Create an API token at https://chaturbate.com/statsapi/authtoken/ with Events API scope.:
+# Create an API token at https://chaturbate.com/statsapi/authtoken/ with Events API scope.
 
 CB_EVENTS_URL="https://eventsapi.chaturbate.com/events/your_username/your_api_token/"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-# Chaturbate API credentials
-# Get these from your Chaturbate account settings
-CB_USERNAME=your_chaturbate_username
-CB_TOKEN=your_api_token_here
+# Create an API token at https://chaturbate.com/statsapi/authtoken/ with Events API scope.:
+
+CB_EVENTS_URL="https://eventsapi.chaturbate.com/events/your_username/your_api_token/"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -257,12 +257,13 @@ jobs:
         run: uv cache prune --ci
 
   e2e:
-    name: E2E Tests
+    name: Live E2E Tests
     needs: build
     if: needs.build.outputs.released == 'true'
     runs-on: ubuntu-24.04
     environment: e2e
     env:
+      CB_RUN_LIVE_TESTS: "1"
       CB_EVENTS_URL: ${{ secrets.CB_EVENTS_URL }}
     permissions:
       contents: read
@@ -294,8 +295,8 @@ jobs:
       - name: Install built wheel
         run: uv pip install dist/cb_events-*.whl
 
-      - name: Run E2E tests
-        run: make test-e2e
+      - name: Run live E2E tests
+        run: make test-live
 
       - name: Prune uv cache
         run: uv cache prune --ci

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -33,8 +33,8 @@ jobs:
           enable-cache: true
           cache-suffix: lint-3.13-${{ hashFiles('uv.lock') }}
 
-      - name: Sync lint dependencies
-        run: uv sync --group=lint --frozen
+      - name: Sync lint and docs dependencies
+        run: uv sync --group=lint --group=docs --frozen
 
       - name: Verify requirements.txt is up to date
         run: make requirements-check
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment: e2e
     env:
-        CB_EVENTS_URL: ${{ secrets.CB_EVENTS_URL }}
+      CB_EVENTS_URL: ${{ secrets.CB_EVENTS_URL }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -263,8 +263,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment: e2e
     env:
-      CB_USERNAME: ${{ secrets.CB_USERNAME }}
-      CB_TOKEN: ${{ secrets.CB_TOKEN }}
+        CB_EVENTS_URL: ${{ secrets.CB_EVENTS_URL }}
     permissions:
       contents: read
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/api/
+docs/html_local_check/
 
 # PyBuilder
 .pybuilder/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: format-docs-rst
+        name: format docs rst files
+        entry: uv run --group=docs docstrfmt
+        language: system
+        files: ^docs/.*\.rst$
       - id: requirements-sync
         name: requirements.txt sync check
         entry: bash -c 'uv export --format requirements-txt --no-hashes --no-default-groups --output-file=requirements.txt && git diff --exit-code -- requirements.txt'

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test-e2e: ## Run mocked end-to-end tests.
 	$(PYTEST) -m "e2e and not live"
 
 test-live: ## Run live end-to-end tests (requires CB_RUN_LIVE_TESTS=1 and CB_EVENTS_URL).
-	$(PYTEST) -m live
+	$(PYTEST) -m "live and e2e"
 
 docs: ## Build documentation.
 	rm -rf docs/_build docs/api

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ XENON_ARGS ?= --max-absolute B --max-modules A --ignore tests
 .PHONY: security security-full bandit pip-audit trivy zizmor
 .PHONY: requirements-export requirements-check
 .PHONY: test test-cov test-e2e
-.PHONY: docs docs-serve docs-linkcheck
+.PHONY: docs docs-serve docs-linkcheck docs-format docs-format-check
 .PHONY: build ci clean help
 
 all: ci ## Run CI-equivalent checks locally.
@@ -39,6 +39,7 @@ fix: ## Apply Ruff autofixes and format code.
 check: ## Run non-mutating style and lint checks.
 	$(UV) run ruff format --check
 	$(UV) run ruff check
+	$(UV) run --group=docs docstrfmt --check docs
 
 type-check: ## Run static type checks.
 	$(UV) run basedpyright
@@ -112,6 +113,12 @@ docs-serve: docs ## Build docs and serve locally on port 8000.
 
 docs-linkcheck: ## Validate docs links.
 	$(UV) run sphinx-build -b linkcheck docs docs/_build/linkcheck
+
+docs-format: ## Format reStructuredText docs files.
+	$(UV) run --group=docs docstrfmt docs
+
+docs-format-check: ## Check reStructuredText docs formatting.
+	$(UV) run --group=docs docstrfmt --check docs
 
 build: ## Build source and wheel distributions.
 	$(UV) build

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-live: ## Run live end-to-end tests (requires CB_RUN_LIVE_TESTS=1 and CB_EVE
 	$(PYTEST) -m "live and e2e"
 
 docs: ## Build documentation.
-	rm -rf docs/_build docs/api
+	rm -rf docs/_build docs/api docs/html_local_check
 	$(UV) run sphinx-build -E -b html docs docs/_build/html
 
 docs-serve: docs ## Build docs and serve locally on port 8000.
@@ -133,7 +133,7 @@ clean: ## Remove caches, artifacts, and generated reports.
 	find . -name "*.py[co]" -delete
 	rm -rf .pytest_cache/ .ruff_cache/ .pyright/ .coverage
 	rm -rf coverage.xml junit.xml htmlcov/ dist/ build/
-	rm -rf *.sarif docs/_build/ docs/api/
+	rm -rf *.sarif docs/_build/ docs/api/ docs/html_local_check/
 
 help: ## Show available targets.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nAvailable targets:\n\n"} /^[a-zA-Z0-9_.-]+:.*##/ {printf "  %-18s %s\n", $$1, $$2} END {print ""}' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ XENON_ARGS ?= --max-absolute B --max-modules A --ignore tests
 .PHONY: format fix check type-check lint check-all pre-commit
 .PHONY: security security-full bandit pip-audit trivy zizmor
 .PHONY: requirements-export requirements-check
-.PHONY: test test-cov test-e2e
+.PHONY: test test-cov test-e2e test-live
 .PHONY: docs docs-serve docs-linkcheck docs-format docs-format-check
 .PHONY: build ci clean help
 
@@ -94,14 +94,17 @@ trivy: ## Run Trivy vulnerability and config scans.
 	trivy fs --severity HIGH,CRITICAL --include-dev-deps --scanners vuln --format table .
 	trivy config --severity HIGH,CRITICAL --format table .
 
-test: ## Run test suite.
-	$(PYTEST)
+test: ## Run test suite (excluding live tests).
+	$(PYTEST) -m "not live"
 
-test-cov: ## Run tests with coverage and JUnit output.
-	$(PYTEST) $(PYTEST_COV_ARGS)
+test-cov: ## Run tests with coverage and JUnit output (excluding live tests).
+	$(PYTEST) -m "not live" $(PYTEST_COV_ARGS)
 
-test-e2e: ## Run end-to-end tests only.
-	$(PYTEST) -m e2e
+test-e2e: ## Run mocked end-to-end tests.
+	$(PYTEST) -m "e2e and not live"
+
+test-live: ## Run live end-to-end tests (requires CB_RUN_LIVE_TESTS=1 and CB_EVENTS_URL).
+	$(PYTEST) -m live
 
 docs: ## Build documentation.
 	rm -rf docs/_build docs/api

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ from cb_events import EventClient, EventType, Router
 
 router = Router()
 
-username = "your_username"
-token = "your_api_token"
+events_url = "https://eventsapi.chaturbate.com/events/your_username/your_api_token/"
 
 
 @router.on(EventType.TIP)
@@ -46,7 +45,7 @@ async def handle_tip(event) -> None:
 
 
 async def main() -> None:
-    async with EventClient(username, token) as client:
+    async with EventClient(events_url) as client:
         async for event in client:
             await router.dispatch(event)
 
@@ -64,7 +63,7 @@ asyncio.run(main())
 - Typed event models for tips, chat/messages, follows, broadcasts, and other event types.
 - Router handlers are registered by event type.
 - Retry and rate-limiting support.
-- Client configuration for timeouts, strict validation, and testbed usage.
+- Client configuration for timeouts, strict validation, and retries.
 
 ## Links
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
-Changelog
-=========
+###########
+ Changelog
+###########
 
 .. include:: ../CHANGELOG.md
-   :parser: myst_parser.sphinx_
+    :parser: myst_parser.sphinx_

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -10,7 +10,6 @@ Client Configuration
 
    config = ClientConfig(
        timeout=10,                   # Server long-poll timeout (seconds)
-       use_testbed=False,            # Use testbed endpoint
        strict_validation=False,      # Raise on invalid events vs. skip
        retry_attempts=8,             # Total attempts (initial + retries)
        retry_backoff=1.0,            # Initial backoff (seconds)
@@ -19,7 +18,7 @@ Client Configuration
 
    )
 
-   client = EventClient(username, token, config=config)
+   client = EventClient(events_url, config=config)
 
 Timeout Settings
 ----------------
@@ -55,19 +54,19 @@ Validation Mode
 
 ``strict_validation=True``: raises ``pydantic.ValidationError`` on invalid event data.
 
-Testbed Environment
--------------------
+Environment Selection
+---------------------
 
-Register a free account at `https://www.testbed.cb.dev <https://www.testbed.cb.dev>`_.
-New accounts come with preloaded tokens so you can test features and apps immediately.
-Generate an API token the same way as a live account, then set ``use_testbed=True``:
+Pass the upstream URL directly to ``EventClient``. Hostname determines
+production vs testbed automatically.
 
 .. code-block:: python
 
-   config = ClientConfig(use_testbed=True)
-   client = EventClient(username, token, config=config)
+   prod_url = "https://eventsapi.chaturbate.com/events/username/token/"
+   testbed_url = "https://events.testbed.cb.dev/events/username/token/"
 
-Connects to ``https://events.testbed.cb.dev/events``.
+   prod_client = EventClient(prod_url)
+   testbed_client = EventClient(testbed_url)
 
 Rate Limiting
 -------------
@@ -82,7 +81,7 @@ Custom Rate Limiter
    from aiolimiter import AsyncLimiter
 
    limiter = AsyncLimiter(max_rate=1000, time_period=60)
-   client = EventClient(username, token, rate_limiter=limiter)
+   client = EventClient(events_url, rate_limiter=limiter)
 
 Shared Rate Limiter
 ~~~~~~~~~~~~~~~~~~~
@@ -96,9 +95,9 @@ Shared Rate Limiter
 
    limiter = AsyncLimiter(max_rate=2000, time_period=60)
 
-   client1 = EventClient(username1, token1, rate_limiter=limiter)
-   client2 = EventClient(username2, token2, rate_limiter=limiter)
-   client3 = EventClient(username3, token3, rate_limiter=limiter)
+   client1 = EventClient(url1, rate_limiter=limiter)
+   client2 = EventClient(url2, rate_limiter=limiter)
+   client3 = EventClient(url3, rate_limiter=limiter)
 
 Logging
 -------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,118 +1,126 @@
-Configuration
-=============
+###############
+ Configuration
+###############
 
-Client Configuration
---------------------
-
-.. code-block:: python
-
-   from cb_events import EventClient, ClientConfig
-
-   config = ClientConfig(
-       timeout=10,                   # Server long-poll timeout (seconds)
-       strict_validation=False,      # Raise on invalid events vs. skip
-       retry_attempts=8,             # Total attempts (initial + retries)
-       retry_backoff=1.0,            # Initial backoff (seconds)
-       retry_factor=2.0,             # Backoff multiplier
-       retry_max_delay=30.0,         # Max retry delay (seconds)
-
-   )
-
-   client = EventClient(events_url, config=config)
-
-Timeout Settings
-----------------
-
-The ``timeout`` parameter controls the maximum time (in seconds) the
-Chaturbate server will wait before sending back a response.
+**********************
+ Client Configuration
+**********************
 
 .. code-block:: python
 
-   config = ClientConfig(timeout=5)   # More frequent polls
-   config = ClientConfig(timeout=30)  # Server holds connection longer
+    from cb_events import EventClient, ClientConfig
+
+    config = ClientConfig(
+        timeout=10,  # Server long-poll timeout (seconds)
+        strict_validation=False,  # Raise on invalid events vs. skip
+        retry_attempts=8,  # Total attempts (initial + retries)
+        retry_backoff=1.0,  # Initial backoff (seconds)
+        retry_factor=2.0,  # Backoff multiplier
+        retry_max_delay=30.0,  # Max retry delay (seconds)
+    )
+
+    client = EventClient(events_url, config=config)
+
+******************
+ Timeout Settings
+******************
+
+The ``timeout`` parameter controls the maximum time (in seconds) the Chaturbate server
+will wait before sending back a response.
+
+.. code-block:: python
+
+    config = ClientConfig(timeout=5)  # More frequent polls
+    config = ClientConfig(timeout=30)  # Server holds connection longer
 
 Default: 10 seconds
 
-Retry Configuration
--------------------
+*********************
+ Retry Configuration
+*********************
 
 .. code-block:: python
 
-   config = ClientConfig(
-       retry_attempts=5,      # Try 5 times total
-       retry_backoff=2.0,     # Start with 2s delay
-       retry_factor=1.5,      # Increase by 1.5x each retry
-       retry_max_delay=60.0,  # Cap delays at 60s
-   )
+    config = ClientConfig(
+        retry_attempts=5,  # Try 5 times total
+        retry_backoff=2.0,  # Start with 2s delay
+        retry_factor=1.5,  # Increase by 1.5x each retry
+        retry_max_delay=60.0,  # Cap delays at 60s
+    )
 
 Retries on 429, 5xx, Cloudflare 521-524. Never retries 401/403.
 
-Validation Mode
----------------
+*****************
+ Validation Mode
+*****************
 
 ``strict_validation=False`` (default): skips invalid events and logs a warning.
 
 ``strict_validation=True``: raises ``pydantic.ValidationError`` on invalid event data.
 
-Environment Selection
----------------------
+***********************
+ Environment Selection
+***********************
 
-Pass the upstream URL directly to ``EventClient``. Hostname determines
-production vs testbed automatically.
+Pass the upstream URL directly to ``EventClient``. Hostname determines production vs
+testbed automatically.
 
 .. code-block:: python
 
-   prod_url = "https://eventsapi.chaturbate.com/events/username/token/"
-   testbed_url = "https://events.testbed.cb.dev/events/username/token/"
+    prod_url = "https://eventsapi.chaturbate.com/events/username/token/"
+    testbed_url = "https://events.testbed.cb.dev/events/username/token/"
 
-   prod_client = EventClient(prod_url)
-   testbed_client = EventClient(testbed_url)
+    prod_client = EventClient(prod_url)
+    testbed_client = EventClient(testbed_url)
 
-Rate Limiting
--------------
+***************
+ Rate Limiting
+***************
 
 Default: 2000 requests per 60 seconds per client.
 
 Custom Rate Limiter
-~~~~~~~~~~~~~~~~~~~
+===================
 
 .. code-block:: python
 
-   from aiolimiter import AsyncLimiter
+    from aiolimiter import AsyncLimiter
 
-   limiter = AsyncLimiter(max_rate=1000, time_period=60)
-   client = EventClient(events_url, rate_limiter=limiter)
+    limiter = AsyncLimiter(max_rate=1000, time_period=60)
+    client = EventClient(events_url, rate_limiter=limiter)
 
 Shared Rate Limiter
-~~~~~~~~~~~~~~~~~~~
+===================
 
 .. warning::
 
-   Each client gets its own independent budget by default. Multiple clients
-   without a shared limiter multiply the effective request rate.
+    Each client gets its own independent budget by default. Multiple clients without a
+    shared limiter multiply the effective request rate.
 
 .. code-block:: python
 
-   limiter = AsyncLimiter(max_rate=2000, time_period=60)
+    limiter = AsyncLimiter(max_rate=2000, time_period=60)
 
-   client1 = EventClient(url1, rate_limiter=limiter)
-   client2 = EventClient(url2, rate_limiter=limiter)
-   client3 = EventClient(url3, rate_limiter=limiter)
+    client1 = EventClient(url1, rate_limiter=limiter)
+    client2 = EventClient(url2, rate_limiter=limiter)
+    client3 = EventClient(url3, rate_limiter=limiter)
 
-Logging
--------
+*********
+ Logging
+*********
 
 Set the logger to ``DEBUG`` for verbose polling URLs and event dispatch data:
 
 .. code-block:: python
 
-   import logging
-   logging.getLogger("cb_events").setLevel(logging.DEBUG)
+    import logging
+
+    logging.getLogger("cb_events").setLevel(logging.DEBUG)
 
 **Example DEBUG Output:**
 
 .. code-block:: text
 
-   DEBUG:cb_events.client:Polling https://eventsapi.chaturbate.com/events/user/************************/?timeout=10
-   DEBUG:cb_events.client:Received 1 events for user
-   DEBUG:cb_events.router:Dispatching chatMessage event 1775683684418-0 to 2 handlers
+    DEBUG:cb_events.client:Polling https://eventsapi.chaturbate.com/events/user/************************/?timeout=10
+    DEBUG:cb_events.client:Received 1 events for user
+    DEBUG:cb_events.router:Dispatching chatMessage event 1775683684418-0 to 2 handlers

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -1,61 +1,66 @@
-Error Handling
-==============
+################
+ Error Handling
+################
 
-Exception Hierarchy
--------------------
+*********************
+ Exception Hierarchy
+*********************
 
 .. code-block:: text
 
-   EventsError (base)
-   ├── AuthError (401/403)
-   └── HttpStatusError
-       ├── ClientRequestError (4xx)
-       ├── RateLimitError (429)
-       └── ServerError (5xx/52x)
+    EventsError (base)
+    ├── AuthError (401/403)
+    └── HttpStatusError
+        ├── ClientRequestError (4xx)
+        ├── RateLimitError (429)
+        └── ServerError (5xx/52x)
 
-``AuthError`` is a subclass of ``EventsError``, so ``except EventsError`` catches
-both. Put ``AuthError`` first if you need to handle the two cases differently.
+``AuthError`` is a subclass of ``EventsError``, so ``except EventsError`` catches both.
+Put ``AuthError`` first if you need to handle the two cases differently.
 
-Basic Error Handling
---------------------
+**********************
+ Basic Error Handling
+**********************
 
 .. code-block:: python
 
-   from cb_events import EventClient, EventsError
+    from cb_events import EventClient, EventsError
 
-   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+    events_url = "https://eventsapi.chaturbate.com/events/username/token/"
 
-   try:
-       async with EventClient(events_url) as client:
-           async for event in client:
-               await router.dispatch(event)
-   except EventsError as e:
-       print(f"Error: {e}")
-       print(f"Status code: {e.status_code}")
-       print(f"Response: {e.response_text}")
+    try:
+        async with EventClient(events_url) as client:
+            async for event in client:
+                await router.dispatch(event)
+    except EventsError as e:
+        print(f"Error: {e}")
+        print(f"Status code: {e.status_code}")
+        print(f"Response: {e.response_text}")
 
-Authentication Errors
-----------------------
+***********************
+ Authentication Errors
+***********************
 
 :class:`~cb_events.exceptions.AuthError` (401/403) is never retried:
 
 .. code-block:: python
 
-   from cb_events import EventClient, AuthError, EventsError
+    from cb_events import EventClient, AuthError, EventsError
 
-   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+    events_url = "https://eventsapi.chaturbate.com/events/username/token/"
 
-   try:
-       async with EventClient(events_url) as client:
-           async for event in client:
-               await router.dispatch(event)
-   except AuthError as e:
-       print(f"Authentication failed: {e} (status {e.status_code})")
-   except EventsError as e:
-       print(f"API error: {e}")
+    try:
+        async with EventClient(events_url) as client:
+            async for event in client:
+                await router.dispatch(event)
+    except AuthError as e:
+        print(f"Authentication failed: {e} (status {e.status_code})")
+    except EventsError as e:
+        print(f"API error: {e}")
 
-Automatic Retries
------------------
+*******************
+ Automatic Retries
+*******************
 
 **Retriable**: 429, 500, 502, 503, 504, 521-524
 
@@ -63,142 +68,151 @@ Automatic Retries
 
 .. code-block:: python
 
-   from cb_events import ClientConfig
+    from cb_events import ClientConfig
 
-   config = ClientConfig(
-       retry_attempts=5,       # Total attempts (1 initial + 4 retries)
-       retry_backoff=1.0,      # Initial delay (seconds)
-       retry_factor=2.0,       # Exponential multiplier
-       retry_max_delay=30.0,   # Cap delay at 30s
-   )
+    config = ClientConfig(
+        retry_attempts=5,  # Total attempts (1 initial + 4 retries)
+        retry_backoff=1.0,  # Initial delay (seconds)
+        retry_factor=2.0,  # Exponential multiplier
+        retry_max_delay=30.0,  # Cap delay at 30s
+    )
 
-Validation Errors
------------------
+*******************
+ Validation Errors
+*******************
 
 Lenient mode (default) skips invalid events and logs them as a warning:
 
 .. code-block:: python
 
-   config = ClientConfig(strict_validation=False)
+    config = ClientConfig(strict_validation=False)
     async with EventClient(events_url, config=config) as client:
-       async for event in client:
-           await router.dispatch(event)
+        async for event in client:
+            await router.dispatch(event)
 
 Strict mode raises ``pydantic.ValidationError`` on invalid event data:
 
 .. code-block:: python
 
-   config = ClientConfig(strict_validation=True)
+    config = ClientConfig(strict_validation=True)
     client = EventClient(events_url, config=config)
 
-   try:
-       async for event in client:
-           await router.dispatch(event)
-   except pydantic.ValidationError as e:
-       print(f"Invalid event data: {e}")
+    try:
+        async for event in client:
+            await router.dispatch(event)
+    except pydantic.ValidationError as e:
+        print(f"Invalid event data: {e}")
 
-Handler Errors
---------------
-
-.. code-block:: python
-
-   @router.on(EventType.TIP)
-   async def buggy_handler(event: Event) -> None:
-       raise ValueError("Oops!")
-
-   @router.on(EventType.TIP)
-   async def working_handler(event: Event) -> None:
-       print("This still runs")
-
-Graceful Shutdown
------------------
+****************
+ Handler Errors
+****************
 
 .. code-block:: python
 
-   import asyncio
-   import signal
-   from cb_events import EventClient
+    @router.on(EventType.TIP)
+    async def buggy_handler(event: Event) -> None:
+        raise ValueError("Oops!")
+
+
+    @router.on(EventType.TIP)
+    async def working_handler(event: Event) -> None:
+        print("This still runs")
+
+*******************
+ Graceful Shutdown
+*******************
+
+.. code-block:: python
+
+    import asyncio
+    import signal
+    from cb_events import EventClient
 
     events_url = "https://eventsapi.chaturbate.com/events/username/token/"
 
-   async def main():
-       loop = asyncio.get_running_loop()
-       task = asyncio.current_task()
-       for sig in (signal.SIGTERM, signal.SIGINT):
-           loop.add_signal_handler(sig, task.cancel)
 
-       try:
-           async with EventClient(events_url) as client:
-               async for event in client:
-                   await router.dispatch(event)
-       except asyncio.CancelledError:
-           print("Shutting down")
+    async def main():
+        loop = asyncio.get_running_loop()
+        task = asyncio.current_task()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, task.cancel)
 
-   asyncio.run(main())
+        try:
+            async with EventClient(events_url) as client:
+                async for event in client:
+                    await router.dispatch(event)
+        except asyncio.CancelledError:
+            print("Shutting down")
+
+
+    asyncio.run(main())
 
 .. note::
 
-   ``loop.add_signal_handler()`` is Unix-only and raises ``NotImplementedError``
-   on Windows. To support Windows, either:
+    ``loop.add_signal_handler()`` is Unix-only and raises ``NotImplementedError`` on
+    Windows. To support Windows, either:
 
-   1. Wrap the calls in a ``try/except NotImplementedError`` block and fall back
-      to ``signal.signal()`` or another cancellation mechanism.
-   2. Implement a Windows-specific shutdown trigger (e.g. ``signal.signal`` with
-      an ``asyncio.Event``) for cross-platform behaviour.
+    1. Wrap the calls in a ``try/except NotImplementedError`` block and fall back to
+       ``signal.signal()`` or another cancellation mechanism.
+    2. Implement a Windows-specific shutdown trigger (e.g. ``signal.signal`` with an
+       ``asyncio.Event``) for cross-platform behaviour.
 
-Network Errors
---------------
-
-.. code-block:: python
-
-   from cb_events import EventsError
-
-   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
-
-   try:
-       async with EventClient(events_url) as client:
-           async for event in client:
-               await router.dispatch(event)
-   except EventsError as e:
-       if e.status_code:
-           print(f"API error: {e.status_code}")
-       else:
-           print(f"Network error: {e}")
-
-Example
--------
+****************
+ Network Errors
+****************
 
 .. code-block:: python
 
-   import asyncio
-   import logging
-   from cb_events import EventClient, AuthError, EventsError
+    from cb_events import EventsError
 
-   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+    events_url = "https://eventsapi.chaturbate.com/events/username/token/"
 
-   logging.basicConfig(level=logging.INFO)
-   logger = logging.getLogger(__name__)
+    try:
+        async with EventClient(events_url) as client:
+            async for event in client:
+                await router.dispatch(event)
+    except EventsError as e:
+        if e.status_code:
+            print(f"API error: {e.status_code}")
+        else:
+            print(f"Network error: {e}")
 
-   async def run_client():
-       while True:
-           try:
-               async with EventClient(events_url) as client:
-                   logger.info("Connected to Events API")
-                   async for event in client:
-                       await router.dispatch(event)
+*********
+ Example
+*********
 
-           except AuthError as e:
-               logger.error(f"Authentication failed: {e}")
-               break
+.. code-block:: python
 
-           except EventsError as e:
-               logger.error(f"API error: {e}")
-               await asyncio.sleep(5)
+    import asyncio
+    import logging
+    from cb_events import EventClient, AuthError, EventsError
 
-           except asyncio.CancelledError:
-               logger.info("Shutting down")
-               raise
+    events_url = "https://eventsapi.chaturbate.com/events/username/token/"
 
-           except Exception as e:
-               logger.exception(f"Unexpected error: {e}")
-               await asyncio.sleep(5)
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+
+    async def run_client():
+        while True:
+            try:
+                async with EventClient(events_url) as client:
+                    logger.info("Connected to Events API")
+                    async for event in client:
+                        await router.dispatch(event)
+
+            except AuthError as e:
+                logger.error(f"Authentication failed: {e}")
+                break
+
+            except EventsError as e:
+                logger.error(f"API error: {e}")
+                await asyncio.sleep(5)
+
+            except asyncio.CancelledError:
+                logger.info("Shutting down")
+                raise
+
+            except Exception as e:
+                logger.exception(f"Unexpected error: {e}")
+                await asyncio.sleep(5)

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -23,8 +23,10 @@ Basic Error Handling
 
    from cb_events import EventClient, EventsError
 
+   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+
    try:
-       async with EventClient(username, token) as client:
+       async with EventClient(events_url) as client:
            async for event in client:
                await router.dispatch(event)
    except EventsError as e:
@@ -41,8 +43,10 @@ Authentication Errors
 
    from cb_events import EventClient, AuthError, EventsError
 
+   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+
    try:
-       async with EventClient(username, token) as client:
+       async with EventClient(events_url) as client:
            async for event in client:
                await router.dispatch(event)
    except AuthError as e:
@@ -76,7 +80,7 @@ Lenient mode (default) skips invalid events and logs them as a warning:
 .. code-block:: python
 
    config = ClientConfig(strict_validation=False)
-   async with EventClient(username, token, config=config) as client:
+    async with EventClient(events_url, config=config) as client:
        async for event in client:
            await router.dispatch(event)
 
@@ -85,7 +89,7 @@ Strict mode raises ``pydantic.ValidationError`` on invalid event data:
 .. code-block:: python
 
    config = ClientConfig(strict_validation=True)
-   client = EventClient(username, token, config=config)
+    client = EventClient(events_url, config=config)
 
    try:
        async for event in client:
@@ -115,6 +119,8 @@ Graceful Shutdown
    import signal
    from cb_events import EventClient
 
+    events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+
    async def main():
        loop = asyncio.get_running_loop()
        task = asyncio.current_task()
@@ -122,7 +128,7 @@ Graceful Shutdown
            loop.add_signal_handler(sig, task.cancel)
 
        try:
-           async with EventClient(username, token) as client:
+           async with EventClient(events_url) as client:
                async for event in client:
                    await router.dispatch(event)
        except asyncio.CancelledError:
@@ -147,8 +153,10 @@ Network Errors
 
    from cb_events import EventsError
 
+   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+
    try:
-       async with EventClient(username, token) as client:
+       async with EventClient(events_url) as client:
            async for event in client:
                await router.dispatch(event)
    except EventsError as e:
@@ -166,13 +174,15 @@ Example
    import logging
    from cb_events import EventClient, AuthError, EventsError
 
+   events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+
    logging.basicConfig(level=logging.INFO)
    logger = logging.getLogger(__name__)
 
    async def run_client():
        while True:
            try:
-               async with EventClient(username, token) as client:
+               async with EventClient(events_url) as client:
                    logger.info("Connected to Events API")
                    async for event in client:
                        await router.dispatch(event)

--- a/docs/event_models.rst
+++ b/docs/event_models.rst
@@ -1,195 +1,200 @@
-Event Models
-============
+##############
+ Event Models
+##############
 
 Property accessors return the nested model or ``None`` if absent or wrong event type.
 
 .. code-block:: python
 
-   event.user          # User object (most events)
-   event.tip           # Tip object (TIP only)
-   event.message       # Message object (CHAT_MESSAGE, PRIVATE_MESSAGE)
-   event.media         # Media object (MEDIA_PURCHASE)
-   event.room_subject  # RoomSubject object (ROOM_SUBJECT_CHANGE)
-   event.broadcaster   # Broadcaster username string, or None if missing
+    event.user  # User object (most events)
+    event.tip  # Tip object (TIP only)
+    event.message  # Message object (CHAT_MESSAGE, PRIVATE_MESSAGE)
+    event.media  # Media object (MEDIA_PURCHASE)
+    event.room_subject  # RoomSubject object (ROOM_SUBJECT_CHANGE)
+    event.broadcaster  # Broadcaster username string, or None if missing
 
 .. warning::
 
-   All string fields (e.g. ``message.message``, ``user.username``,
-   ``tip.message``) originate from untrusted user input and are **not**
-   sanitized by this library. Escape or validate them before use in HTML,
-   SQL, or shell contexts.
+    All string fields (e.g. ``message.message``, ``user.username``, ``tip.message``)
+    originate from untrusted user input and are **not** sanitized by this library.
+    Escape or validate them before use in HTML, SQL, or shell contexts.
 
 ----
 
-User
-----
+******
+ User
+******
 
 Carried by most event types. Check ``event.user`` before accessing fields.
 
 .. list-table::
-   :header-rows: 1
-   :widths: 25 20 55
+    :header-rows: 1
+    :widths: 25 20 55
 
-   * - Field
-     - Type
-     - Description
-   * - ``username``
-     - ``str``
-     - Display name of the user.
-   * - ``in_fanclub``
-     - ``bool``
-     - Whether the user is in the fan club.
-   * - ``is_mod``
-     - ``bool``
-     - Whether the user is a moderator.
-   * - ``is_follower``
-     - ``bool``
-     - Whether the user is a follower.
-   * - ``is_owner``
-     - ``bool``
-     - Whether the user is the room owner.
-   * - ``has_tokens``
-     - ``bool``
-     - Whether the user has tokens.
-   * - ``is_broadcasting``
-     - ``bool``
-     - Whether the user is currently broadcasting.
-   * - ``in_private_show``
-     - ``bool``
-     - Whether the user is in a private show.
-   * - ``is_spying``
-     - ``bool``
-     - Whether the user is spying on a private show.
-   * - ``is_silenced``
-     - ``bool``
-     - Whether the user is silenced.
-   * - ``has_darkmode``
-     - ``bool``
-     - Whether the user has dark mode enabled.
-   * - ``fc_auto_renew``
-     - ``bool``
-     - Whether fan club auto-renewal is enabled.
-   * - ``color_group``
-     - ``str | None``
-     - Color group of the user.
-   * - ``gender``
-     - ``str | None``
-     - Gender of the user.
-   * - ``language``
-     - ``str | None``
-     - Language preference of the user.
-   * - ``recent_tips``
-     - ``Literal["none", "few", "some", "lots", "tons"] | None``
-     - Recent tip activity level.
-   * - ``subgender``
-     - ``str | None``
-     - Subgender of the user.
+    - - Field
+      - Type
+      - Description
+    - - ``username``
+      - ``str``
+      - Display name of the user.
+    - - ``in_fanclub``
+      - ``bool``
+      - Whether the user is in the fan club.
+    - - ``is_mod``
+      - ``bool``
+      - Whether the user is a moderator.
+    - - ``is_follower``
+      - ``bool``
+      - Whether the user is a follower.
+    - - ``is_owner``
+      - ``bool``
+      - Whether the user is the room owner.
+    - - ``has_tokens``
+      - ``bool``
+      - Whether the user has tokens.
+    - - ``is_broadcasting``
+      - ``bool``
+      - Whether the user is currently broadcasting.
+    - - ``in_private_show``
+      - ``bool``
+      - Whether the user is in a private show.
+    - - ``is_spying``
+      - ``bool``
+      - Whether the user is spying on a private show.
+    - - ``is_silenced``
+      - ``bool``
+      - Whether the user is silenced.
+    - - ``has_darkmode``
+      - ``bool``
+      - Whether the user has dark mode enabled.
+    - - ``fc_auto_renew``
+      - ``bool``
+      - Whether fan club auto-renewal is enabled.
+    - - ``color_group``
+      - ``str | None``
+      - Color group of the user.
+    - - ``gender``
+      - ``str | None``
+      - Gender of the user.
+    - - ``language``
+      - ``str | None``
+      - Language preference of the user.
+    - - ``recent_tips``
+      - ``Literal["none", "few", "some", "lots", "tons"] | None``
+      - Recent tip activity level.
+    - - ``subgender``
+      - ``str | None``
+      - Subgender of the user.
 
 ----
 
-Tip
----
+*****
+ Tip
+*****
 
 Present on ``TIP`` events only. Access via ``event.tip``.
 
 .. list-table::
-   :header-rows: 1
-   :widths: 25 20 55
+    :header-rows: 1
+    :widths: 25 20 55
 
-   * - Field
-     - Type
-     - Description
-   * - ``tokens``
-     - ``int``
-     - Number of tokens tipped.
-   * - ``is_anon``
-     - ``bool``
-     - Whether the tip is anonymous.
-   * - ``message``
-     - ``str | None``
-     - Optional message attached to the tip.
+    - - Field
+      - Type
+      - Description
+    - - ``tokens``
+      - ``int``
+      - Number of tokens tipped.
+    - - ``is_anon``
+      - ``bool``
+      - Whether the tip is anonymous.
+    - - ``message``
+      - ``str | None``
+      - Optional message attached to the tip.
 
 ----
 
-Message
--------
+*********
+ Message
+*********
 
 Present on ``CHAT_MESSAGE`` and ``PRIVATE_MESSAGE`` events. Access via
 ``event.message``.
 
 .. list-table::
-   :header-rows: 1
-   :widths: 25 20 55
+    :header-rows: 1
+    :widths: 25 20 55
 
-   * - Field
-     - Type
-     - Description
-   * - ``message``
-     - ``str``
-     - Content of the message.
-   * - ``from_user``
-     - ``str | None``
-     - Username of the sender (private messages only).
-   * - ``to_user``
-     - ``str | None``
-     - Username of the recipient (private messages only).
-   * - ``color``
-     - ``str | None``
-     - Text color of the message.
-   * - ``bg_color``
-     - ``str | None``
-     - Background color of the message.
-   * - ``font``
-     - ``str | None``
-     - Font style of the message.
-   * - ``orig``
-     - ``str | None``
-     - Original (untranslated) message content.
-   * - ``is_private`` *(property)*
-     - ``bool``
-     - ``True`` when both ``from_user`` and ``to_user`` are set.
+    - - Field
+      - Type
+      - Description
+    - - ``message``
+      - ``str``
+      - Content of the message.
+    - - ``from_user``
+      - ``str | None``
+      - Username of the sender (private messages only).
+    - - ``to_user``
+      - ``str | None``
+      - Username of the recipient (private messages only).
+    - - ``color``
+      - ``str | None``
+      - Text color of the message.
+    - - ``bg_color``
+      - ``str | None``
+      - Background color of the message.
+    - - ``font``
+      - ``str | None``
+      - Font style of the message.
+    - - ``orig``
+      - ``str | None``
+      - Original (untranslated) message content.
+    - - ``is_private`` *(property)*
+      - ``bool``
+      - ``True`` when both ``from_user`` and ``to_user`` are set.
 
 ----
 
-Media
------
+*******
+ Media
+*******
 
 Present on ``MEDIA_PURCHASE`` events. Access via ``event.media``.
 
 .. list-table::
-   :header-rows: 1
-   :widths: 25 20 55
+    :header-rows: 1
+    :widths: 25 20 55
 
-   * - Field
-     - Type
-     - Description
-   * - ``id``
-     - ``str``
-     - Identifier of the purchased media.
-   * - ``name``
-     - ``str``
-     - Name of the purchased media.
-   * - ``type``
-     - ``"video" | "photos"``
-     - Type of the purchased media.
-   * - ``tokens``
-     - ``int``
-     - Number of tokens spent on the purchase.
+    - - Field
+      - Type
+      - Description
+    - - ``id``
+      - ``str``
+      - Identifier of the purchased media.
+    - - ``name``
+      - ``str``
+      - Name of the purchased media.
+    - - ``type``
+      - ``"video" | "photos"``
+      - Type of the purchased media.
+    - - ``tokens``
+      - ``int``
+      - Number of tokens spent on the purchase.
 
 ----
 
-RoomSubject
------------
+*************
+ RoomSubject
+*************
 
 Present on ``ROOM_SUBJECT_CHANGE`` events. Access via ``event.room_subject``.
 
 .. list-table::
-   :header-rows: 1
-   :widths: 25 20 55
+    :header-rows: 1
+    :widths: 25 20 55
 
-   * - Field
-     - Type
-     - Description
-   * - ``subject``
-     - ``str``
-     - The updated room subject or title.
+    - - Field
+      - Type
+      - Description
+    - - ``subject``
+      - ``str``
+      - The updated room subject or title.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,70 +1,76 @@
-cb-events
-=========
+###########
+ cb-events
+###########
 
 .. image:: https://img.shields.io/pypi/v/cb-events
-   :target: https://pypi.org/project/cb-events/
-   :alt: PyPI version
+    :target: https://pypi.org/project/cb-events/
+    :alt: PyPI version
 
 .. image:: https://img.shields.io/pypi/pyversions/cb-events
-   :target: https://pypi.org/project/cb-events/
-   :alt: Python versions
+    :target: https://pypi.org/project/cb-events/
+    :alt: Python versions
 
 .. image:: https://img.shields.io/github/license/MountainGod2/cb-events
-   :target: https://github.com/MountainGod2/cb-events/blob/main/LICENSE
-   :alt: License
+    :target: https://github.com/MountainGod2/cb-events/blob/main/LICENSE
+    :alt: License
 
 .. image:: https://img.shields.io/readthedocs/cb-events
-   :target: https://cb-events.readthedocs.io/
-   :alt: Documentation
+    :target: https://cb-events.readthedocs.io/
+    :alt: Documentation
 
 Async Python client for the Chaturbate Events API.
 
-Example
--------
+*********
+ Example
+*********
 
 .. code-block:: python
 
-   import asyncio
-   from cb_events import EventClient, Router, EventType, Event
+    import asyncio
+    from cb_events import EventClient, Router, EventType, Event
 
-   router = Router()
+    router = Router()
 
-   @router.on(EventType.TIP)
-   async def handle_tip(event: Event) -> None:
-       if event.user and event.tip:
-           print(f"{event.user.username} tipped {event.tip.tokens} tokens")
 
-   async def main():
-          events_url = "https://eventsapi.chaturbate.com/events/username/token/"
-          async with EventClient(events_url) as client:
-           async for event in client:
-               await router.dispatch(event)
+    @router.on(EventType.TIP)
+    async def handle_tip(event: Event) -> None:
+        if event.user and event.tip:
+            print(f"{event.user.username} tipped {event.tip.tokens} tokens")
 
-   asyncio.run(main())
 
-Documentation
--------------
+    async def main():
+        events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+        async with EventClient(events_url) as client:
+            async for event in client:
+                await router.dispatch(event)
 
-.. toctree::
-   :maxdepth: 2
-   :caption: User Guide
 
-   installation
-   quickstart
-   event_models
-   configuration
-   error_handling
+    asyncio.run(main())
+
+***************
+ Documentation
+***************
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Reference
+    :maxdepth: 2
+    :caption: User Guide
 
-   api/cb_events/index
+    installation
+    quickstart
+    event_models
+    configuration
+    error_handling
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Project
+    :maxdepth: 2
+    :caption: Reference
 
-   changelog
-   GitHub Repository <https://github.com/MountainGod2/cb-events>
-   PyPI Package <https://pypi.org/project/cb-events/>
+    api/cb_events/index
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Project
+
+    changelog
+    GitHub Repository <https://github.com/MountainGod2/cb-events>
+    PyPI Package <https://pypi.org/project/cb-events/>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,8 @@ Example
            print(f"{event.user.username} tipped {event.tip.tokens} tokens")
 
    async def main():
-       async with EventClient(username, token) as client:
+          events_url = "https://eventsapi.chaturbate.com/events/username/token/"
+          async with EventClient(events_url) as client:
            async for event in client:
                await router.dispatch(event)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@
     :alt: License
 
 .. image:: https://img.shields.io/readthedocs/cb-events
-    :target: https://cb-events.readthedocs.io/
+    :target: https://cb-events.readthedocs.io/latest/
     :alt: Documentation
 
 Async Python client for the Chaturbate Events API.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,43 +1,48 @@
-Installation
-============
+##############
+ Installation
+##############
 
-Requirements
-------------
+**************
+ Requirements
+**************
 
 Python ≥3.10
 
-Install
--------
+*********
+ Install
+*********
 
 .. code-block:: bash
 
-   pip install cb-events
+    pip install cb-events
 
 Or with uv:
 
 .. code-block:: bash
 
-   uv add cb-events
+    uv add cb-events
 
-Development
------------
+*************
+ Development
+*************
 
 .. code-block:: bash
 
-   git clone https://github.com/MountainGod2/cb-events.git
-   cd cb-events
-   make dev-setup
+    git clone https://github.com/MountainGod2/cb-events.git
+    cd cb-events
+    make dev-setup
 
 Useful local commands:
 
 .. code-block:: bash
 
-   make help
-   make ci
-   make security-full
+    make help
+    make ci
+    make security-full
 
-API Token
----------
+***********
+ API Token
+***********
 
 Create a token at https://chaturbate.com/statsapi/authtoken/ with **Events API** scope.
 
@@ -49,4 +54,4 @@ Authorization notes:
 
 .. code-block:: bash
 
-   export CB_EVENTS_URL="https://eventsapi.chaturbate.com/events/your_username/your_api_token/"
+    export CB_EVENTS_URL="https://eventsapi.chaturbate.com/events/your_username/your_api_token/"

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,5 +49,4 @@ Authorization notes:
 
 .. code-block:: bash
 
-   export CB_USERNAME="your_username"
-   export CB_TOKEN="your_api_token"
+   export CB_EVENTS_URL="https://eventsapi.chaturbate.com/events/your_username/your_api_token/"

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,41 +1,47 @@
-Quick Start
-===========
+#############
+ Quick Start
+#############
 
 .. code-block:: python
 
-   import asyncio
-   from cb_events import EventClient, Router, EventType, Event
+    import asyncio
+    from cb_events import EventClient, Router, EventType, Event
 
-   router = Router()
+    router = Router()
 
     events_url = "https://eventsapi.chaturbate.com/events/your_username/your_api_token/"
 
-   @router.on(EventType.USER_ENTER)
-   async def handle_user_enter(event: Event) -> None:
-       if event.user:
-           print(f"{event.user.username} entered the room")
 
-   @router.on(EventType.TIP)
-   async def handle_tip(event: Event) -> None:
-       if event.user and event.tip:
-           print(f"{event.user.username} tipped {event.tip.tokens} tokens")
+    @router.on(EventType.USER_ENTER)
+    async def handle_user_enter(event: Event) -> None:
+        if event.user:
+            print(f"{event.user.username} entered the room")
 
-   async def main():
-       async with EventClient(events_url) as client:
-           async for event in client:
-               await router.dispatch(event)
 
-   asyncio.run(main())
+    @router.on(EventType.TIP)
+    async def handle_tip(event: Event) -> None:
+        if event.user and event.tip:
+            print(f"{event.user.username} tipped {event.tip.tokens} tokens")
+
+
+    async def main():
+        async with EventClient(events_url) as client:
+            async for event in client:
+                await router.dispatch(event)
+
+
+    asyncio.run(main())
 
 **Example Output:**
 
 .. code-block:: text
 
-   mountaingod2 entered the room
-   mountaingod2 tipped 100 tokens
+    mountaingod2 entered the room
+    mountaingod2 tipped 100 tokens
 
-Event Types
------------
+*************
+ Event Types
+*************
 
 - ``TIP`` — User sends a tip
 - ``FANCLUB_JOIN`` — User joins fan club
@@ -50,32 +56,35 @@ Event Types
 - ``BROADCAST_STOP`` — Broadcast ends
 - ``ROOM_SUBJECT_CHANGE`` — Room subject updated
 
-Catch-All Handler
------------------
+*******************
+ Catch-All Handler
+*******************
 
 .. code-block:: python
 
-   @router.on_any()
-   async def handle_all(event: Event) -> None:
-       print(f"Event type: {event.type}")
+    @router.on_any()
+    async def handle_all(event: Event) -> None:
+        print(f"Event type: {event.type}")
 
-Multiple Handlers
------------------
+*******************
+ Multiple Handlers
+*******************
 
 .. code-block:: python
 
-   @router.on(EventType.TIP)
-   async def log_tip(event: Event) -> None:
-       if event.tip:
-           logging.info(f"Tip received: {event.tip.tokens}")
+    @router.on(EventType.TIP)
+    async def log_tip(event: Event) -> None:
+        if event.tip:
+            logging.info(f"Tip received: {event.tip.tokens}")
 
-   @router.on(EventType.TIP)
-   async def thank_tipper(event: Event) -> None:
-       if event.user:
-           await send_thank_you(event.user.username)
+
+    @router.on(EventType.TIP)
+    async def thank_tipper(event: Event) -> None:
+        if event.user:
+            await send_thank_you(event.user.username)
 
 .. note::
 
-   Handlers run sequentially in registration order. Regular handler exceptions
-   are logged and dispatch continues — a failing handler does not stop the
-   others. ``asyncio.CancelledError`` will propagate immediately.
+    Handlers run sequentially in registration order. Regular handler exceptions are
+    logged and dispatch continues — a failing handler does not stop the others.
+    ``asyncio.CancelledError`` will propagate immediately.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,8 +8,7 @@ Quick Start
 
    router = Router()
 
-   username = "your_username"
-   token = "your_api_token"
+    events_url = "https://eventsapi.chaturbate.com/events/your_username/your_api_token/"
 
    @router.on(EventType.USER_ENTER)
    async def handle_user_enter(event: Event) -> None:
@@ -22,7 +21,7 @@ Quick Start
            print(f"{event.user.username} tipped {event.tip.tokens} tokens")
 
    async def main():
-       async with EventClient(username, token) as client:
+       async with EventClient(events_url) as client:
            async for event in client:
                await router.dispatch(event)
 

--- a/examples/event_handling.py
+++ b/examples/event_handling.py
@@ -110,9 +110,7 @@ async def handle_tip(event: Event) -> None:
     """Handle tip events."""
     if event.user and event.tip:
         anon_text = "anonymously " if event.tip.is_anon else ""
-        clean_message = (
-            event.tip.message.removeprefix("| ") if event.tip.message else ""
-        )
+        clean_message = event.tip.message.removeprefix("| ") if event.tip.message else ""
         message_text = f"with message: {clean_message}" if clean_message else ""
         logger.info(
             "%s sent %s tokens %s",
@@ -150,11 +148,9 @@ async def handle_any_event(event: Event) -> None:
 
 async def main() -> None:
     """Set up event handlers and start listening for events."""
-    username = os.getenv("CB_USERNAME", "")
-    token = os.getenv("CB_TOKEN", "")
-    use_testbed = os.getenv("CB_USE_TESTBED", "false").lower() == "true"
+    events_url = os.getenv("CB_EVENTS_URL", "")
 
-    config = ClientConfig(use_testbed=use_testbed)
+    config = ClientConfig()
 
     loop = asyncio.get_running_loop()
     task = asyncio.current_task()
@@ -163,12 +159,10 @@ async def main() -> None:
             loop.add_signal_handler(sig, task.cancel)
     except NotImplementedError:
         for sig in (signal.SIGTERM, signal.SIGINT):
-            signal.signal(
-                sig, lambda _s, _f: task.cancel() if task is not None else None
-            )
+            signal.signal(sig, lambda _s, _f: task.cancel() if task is not None else None)
 
     try:
-        async with EventClient(username, token, config=config) as client:
+        async with EventClient(events_url, config=config) as client:
             logger.info("Listening for events... (Ctrl+C to stop)")
 
             async for event in client:

--- a/examples/event_handling.py
+++ b/examples/event_handling.py
@@ -148,7 +148,11 @@ async def handle_any_event(event: Event) -> None:
 
 async def main() -> None:
     """Set up event handlers and start listening for events."""
-    events_url = os.getenv("CB_EVENTS_URL", "")
+    events_url = os.getenv("CB_EVENTS_URL")
+
+    if not events_url:
+        msg = "CB_EVENTS_URL environment variable is required"
+        raise RuntimeError(msg)
 
     config = ClientConfig()
 

--- a/examples/tip_activated_lights.py
+++ b/examples/tip_activated_lights.py
@@ -16,8 +16,7 @@ registering a new Hue app key and discovering bridges on the local network.
 
 Usage:
     1. Set up environment variables (or use CLI options):
-        - CB_USERNAME: Chaturbate username
-        - CB_TOKEN: Chaturbate API token
+        - CB_EVENTS_URL: Full Chaturbate Events API URL
         - HUE_IP: Hue bridge IP address (optional if using discovery)
         - HUE_APP_KEY: Hue app key (register with the 'register' command)
         - TIP_THRESHOLD: Minimum tokens for activating lights (default: 35)
@@ -33,7 +32,7 @@ Usage:
 
     4. Optionally, discover Hue bridges on the local network:
         uv run examples/tip_activated_lights.py discover
-"""  # noqa: E501
+"""
 
 import asyncio
 import contextlib
@@ -118,9 +117,7 @@ def setup_logging() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format="%(message)s",
-        handlers=[
-            RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)
-        ],
+        handlers=[RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)],
     )
     logging.getLogger("aiohttp").setLevel(logging.WARNING)
     logging.getLogger("aiohue").setLevel(logging.WARNING)
@@ -154,11 +151,7 @@ def _load_light_config() -> LightConfig:
     Returns:
         LightConfig: The loaded configuration.
     """
-    lights = [
-        name.strip()
-        for name in os.getenv("LIGHT_NAMES", "").split(",")
-        if name.strip()
-    ]
+    lights = [name.strip() for name in os.getenv("LIGHT_NAMES", "").split(",") if name.strip()]
     return LightConfig(
         brightness=_env_float("BRIGHTNESS", DEFAULT_BRIGHTNESS),
         color_timeout=_env_float("COLOR_TIMEOUT", DEFAULT_COLOR_TIMEOUT),
@@ -179,9 +172,7 @@ class HueController:
     how many intermediate colour changes have been requested.
     """
 
-    def __init__(
-        self, bridge: HueBridgeV2, config: LightConfig | None = None
-    ) -> None:
+    def __init__(self, bridge: HueBridgeV2, config: LightConfig | None = None) -> None:
         """Initialize the HueController with a bridge and optional config."""
         self.bridge = bridge
         self.config = config or LightConfig()
@@ -202,8 +193,7 @@ class HueController:
         return [
             light.id
             for light in self.bridge.lights
-            if not self.config.lights
-            or light.metadata.name in self.config.lights  # ty:ignore[unresolved-attribute]
+            if not self.config.lights or light.metadata.name in self.config.lights  # ty:ignore[unresolved-attribute]
         ]
 
     def _capture_states(self) -> dict[str, LightState]:
@@ -221,9 +211,7 @@ class HueController:
                 on=light.on.on if light.on else False,
                 brightness=light.dimming.brightness if light.dimming else None,
                 color_xy=(
-                    (light.color.xy.x, light.color.xy.y)
-                    if light.color and light.color.xy
-                    else None
+                    (light.color.xy.x, light.color.xy.y) if light.color and light.color.xy else None
                 ),
             )
         return states
@@ -304,9 +292,7 @@ class HueController:
                 await self._color_timer
 
         for light_id in self._light_ids:
-            await self._set_light_color(
-                light_id, xy, transition_time=self.config.transition_time
-            )
+            await self._set_light_color(light_id, xy, transition_time=self.config.transition_time)
         logger.info("Lights set to %s", color)
 
         self._color_timer = asyncio.create_task(
@@ -349,25 +335,19 @@ def _register_signal_handlers(task: asyncio.Task[object]) -> None:
             loop.add_signal_handler(sig, task.cancel)
     except NotImplementedError:
         for sig in (signal.SIGTERM, signal.SIGINT):
-            signal.signal(
-                sig, lambda _s, _f: loop.call_soon_threadsafe(task.cancel)
-            )
+            signal.signal(sig, lambda _s, _f: loop.call_soon_threadsafe(task.cancel))
 
 
-async def run_app(*, testbed: bool) -> None:
+async def run_app() -> None:
     """Connect to the Hue bridge and start processing tip events.
-
-    Args:
-        testbed: Whether to use the Chaturbate testbed environment.
 
     Raises:
         RuntimeError: If called outside a running event loop task.
-        ValueError: If ``CB_USERNAME`` or ``CB_TOKEN`` are not set.
+        ValueError: If ``CB_EVENTS_URL`` is not set.
     """
-    username = os.getenv("CB_USERNAME")
-    token = os.getenv("CB_TOKEN")
-    if not username or not token:
-        msg = "CB_USERNAME and CB_TOKEN must be set"
+    events_url = os.getenv("CB_EVENTS_URL")
+    if not events_url:
+        msg = "Set CB_EVENTS_URL"
         raise ValueError(msg)
 
     hue_ip = os.getenv("HUE_IP", DEFAULT_HUE_IP)
@@ -382,7 +362,7 @@ async def run_app(*, testbed: bool) -> None:
     )
 
     router = Router()
-    client_config = ClientConfig(use_testbed=testbed)
+    client_config = ClientConfig()
 
     # Register cancellation signals so Ctrl-C / SIGTERM shuts down cleanly.
     current_task = asyncio.current_task()
@@ -398,19 +378,13 @@ async def run_app(*, testbed: bool) -> None:
 
             @router.on(EventType.TIP)
             async def handle_tip(event: Event) -> None:
-                if (
-                    not event.tip
-                    or event.tip.tokens < tip_threshold
-                    or not event.tip.message
-                ):
+                if not event.tip or event.tip.tokens < tip_threshold or not event.tip.message:
                     return
                 color = _color_from_message(event.tip.message)
                 if color:
                     await hue.set_color(color)
 
-            async with EventClient(
-                username, token, config=client_config
-            ) as client:
+            async with EventClient(events_url, config=client_config) as client:
                 async for event in client:
                     await router.dispatch(event)
     except asyncio.CancelledError:
@@ -428,19 +402,14 @@ def cli() -> None:
 
 
 @cli.command()
-@click.option(
-    "--testbed", is_flag=True, help="Use the Chaturbate testbed environment."
-)
-def run(*, testbed: bool) -> None:
+def run() -> None:
     """Start monitoring tips and activating lights."""
     setup_logging()
     load_dotenv()
     try:
-        asyncio.run(run_app(testbed=testbed))
+        asyncio.run(run_app())
     except AuthError:
-        logger.exception(
-            "Authentication failed — check CB_USERNAME and CB_TOKEN."
-        )
+        logger.exception("Authentication failed - check CB_EVENTS_URL.")
     except Exception:
         logger.exception("Fatal error occurred")
     finally:
@@ -451,10 +420,7 @@ def run(*, testbed: bool) -> None:
 @click.option(
     "--host",
     default=None,
-    help=(
-        "Hue bridge IP or hostname"
-        " (defaults to HUE_IP env var or auto-discovery)."
-    ),
+    help=("Hue bridge IP or hostname (defaults to HUE_IP env var or auto-discovery)."),
 )
 @click.option(
     "--env-file",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ exclude_commit_patterns = [
 
 [tool.ruff]
 target-version = "py310"
-line-length = 80
+line-length = 100
 indent-width = 4
 
 [tool.ruff.lint]
@@ -186,7 +186,7 @@ load-plugins = ["pylint.extensions.typing", "pylint_pydantic"]
 max-attributes = 12
 
 [tool.pylint.format]
-max-line-length = 80
+max-line-length = 100
 
 [tool.basedpyright]
 include = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ asyncio_default_fixture_loop_scope = "function"
 addopts = ["--strict-markers", "--strict-config", "--tb=short", "-ra"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "e2e: marks tests requiring external services",
+    "e2e: marks end-to-end workflow tests",
     "live: marks tests requiring explicit opt-in live credentials",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ test = [
     "pytest-mock==3.15.1",
 ]
 docs = [
+    "docstrfmt==2.0.2",
     "furo==2025.12.19",
     "myst-parser==5.0.0",
     "sphinx==9.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ ignore = [
 future-annotations = true
 
 [tool.ruff.lint.per-file-ignores]
-"examples/*" = ["RUF029", "TC"]
+"examples/*" = ["RUF029", "TC", "DOC"]
 "tests/*" = [
     "ANN",
     "E501",

--- a/src/cb_events/__init__.py
+++ b/src/cb_events/__init__.py
@@ -22,7 +22,9 @@ Example:
                 print(f"{event.user.username} tipped {event.tip.tokens} tokens")
 
         async def main() -> None:
-            async with EventClient("username", "token") as client:
+            async with EventClient(
+                "https://eventsapi.chaturbate.com/events/username/token/"
+            ) as client:
                 async for event in client:
                     await router.dispatch(event)
 

--- a/src/cb_events/client.py
+++ b/src/cb_events/client.py
@@ -139,9 +139,12 @@ def _parse_and_validate_events_url(events_url: str) -> ParseResult:
         msg = "Events URL must not include query parameters or fragments."
         raise AuthError(msg)
 
-    if parsed.port is not None:
-        msg = "Events URL must not include a custom port."
-        raise AuthError(msg)
+    custom_port_msg = "Events URL must not include a custom port."
+    try:
+        if parsed.port is not None:
+            raise AuthError(custom_port_msg)
+    except ValueError as exc:
+        raise AuthError(custom_port_msg) from exc
 
     return parsed
 

--- a/src/cb_events/client.py
+++ b/src/cb_events/client.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import Mapping
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Final, NoReturn, cast
-from urllib.parse import quote, urljoin, urlparse
+from urllib.parse import quote, unquote, urljoin, urlparse
 
 import stamina
 from aiohttp import ClientSession, ClientTimeout
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Sequence
     from types import TracebackType
     from urllib.parse import ParseResult
+
+logger = logging.getLogger(__name__)
+"""Logger for the cb_events.client module."""
 
 BASE_URL: Final[str] = "https://eventsapi.chaturbate.com/events"
 """Production Events API endpoint base."""
@@ -84,8 +87,11 @@ RETRY_STATUS_CODES: Final[frozenset[int]] = frozenset({
 TIMEOUT_STATUS_MESSAGE: Final[str] = "waited too long"
 """Status message indicating API polling timeout."""
 
-logger = logging.getLogger(__name__)
-"""Logger for the cb_events.client module."""
+SUPPORTED_EVENTS_HOSTS: Final[dict[str, str]] = {
+    "eventsapi.chaturbate.com": BASE_URL,
+    "events.testbed.cb.dev": TESTBED_URL,
+}
+"""Allowed Events API hosts mapped to canonical base URLs."""
 
 
 class _TransientError(Exception):
@@ -95,9 +101,7 @@ class _TransientError(Exception):
     status_code: int
     response_text: str
 
-    def __init__(
-        self, msg: str, *, status_code: int, response_text: str
-    ) -> None:
+    def __init__(self, msg: str, *, status_code: int, response_text: str) -> None:
         """Initialize exception with message and HTTP metadata.
 
         Args:
@@ -108,6 +112,133 @@ class _TransientError(Exception):
         super().__init__(msg)
         self.status_code = status_code
         self.response_text = response_text
+
+
+def _parse_and_validate_events_url(events_url: str) -> ParseResult:
+    """Parse the Events URL and validate top-level URL components.
+
+    Args:
+        events_url: Full Events API URL provided by upstream.
+
+    Returns:
+        ParsedResult from urlparse with validated scheme, host, and path format.
+
+    Raises:
+        AuthError: If the URL is malformed or contains invalid components.
+    """
+    if not events_url or events_url != events_url.strip():
+        msg = "Events URL must not be empty or contain leading/trailing whitespace."
+        raise AuthError(msg)
+
+    parsed = urlparse(events_url)
+    if parsed.scheme != "https":
+        msg = "Events URL must use https."
+        raise AuthError(msg)
+
+    if parsed.query or parsed.fragment:
+        msg = "Events URL must not include query parameters or fragments."
+        raise AuthError(msg)
+
+    if parsed.port is not None:
+        msg = "Events URL must not include a custom port."
+        raise AuthError(msg)
+
+    return parsed
+
+
+def _resolve_base_url(hostname: str | None) -> str:
+    """Resolve canonical base URL from a parsed hostname.
+
+    Args:
+        hostname: Hostname extracted from the parsed Events URL.
+
+    Returns:
+        Canonical base URL corresponding to the hostname.
+
+    Raises:
+        AuthError: If the hostname is not in the list of supported hosts.
+    """
+    base_url = SUPPORTED_EVENTS_HOSTS.get((hostname or "").lower())
+    if base_url is not None:
+        return base_url
+    msg = "Events URL host is not supported. Use eventsapi.chaturbate.com or events.testbed.cb.dev."
+    raise AuthError(msg)
+
+
+def _extract_username_token(path: str) -> tuple[str, str]:
+    """Extract and URL-decode username/token from an Events path.
+
+    Args:
+        path: Path component of the Events URL.
+
+    Returns:
+        Tuple of ``(username, token)``.
+
+    Raises:
+        AuthError: If the path does not match the expected format.
+    """
+    parts = [part for part in path.split("/") if part]
+    if len(parts) != 3 or parts[0] != "events":  # noqa: PLR2004
+        msg = "Events URL must match https://<host>/events/<username>/<token>/"
+        raise AuthError(msg)
+    return unquote(parts[1]), unquote(parts[2])
+
+
+def _validate_username(username: str) -> None:
+    """Validate extracted username value.
+
+    Args:
+        username: Extracted username to validate.
+
+    Raises:
+        AuthError: If the username is empty or contains leading/trailing whitespace.
+    """
+    if username and username == username.strip():
+        return
+    msg = (
+        "Username must not be empty or contain leading/trailing "
+        "whitespace. Provide a valid Chaturbate username."
+    )
+    raise AuthError(msg)
+
+
+def _validate_token(token: str) -> None:
+    """Validate extracted token value.
+
+    Args:
+        token: Extracted token to validate.
+
+    Raises:
+        AuthError: If the token is empty or contains leading/trailing whitespace.
+    """
+    if token and token == token.strip():
+        return
+    msg = (
+        "Token must not be empty or contain leading/trailing "
+        "whitespace. Generate a valid token at "
+        "https://chaturbate.com/statsapi/authtoken/"
+    )
+    raise AuthError(msg)
+
+
+def _parse_events_url(events_url: str) -> tuple[str, str, str]:
+    """Parse and validate the Events API URL.
+
+    Args:
+        events_url: Full upstream URL containing host, username, and token.
+
+    Returns:
+        Tuple of ``(base_url, username, token)``.
+
+    Raises:
+        AuthError: If the URL is malformed or contains invalid credentials.
+    """  # noqa: DOC502
+    parsed = _parse_and_validate_events_url(events_url)
+    base_url = _resolve_base_url(parsed.hostname)
+    username, token = _extract_username_token(parsed.path)
+    _validate_username(username)
+    _validate_token(token)
+    return base_url, username, token
 
 
 def _mask_token(token: str, visible: int = TOKEN_VISIBLE_CHARS) -> str:
@@ -190,11 +321,7 @@ def _parse_events(raw: Sequence[object], *, strict: bool) -> list[Event]:
     Returns:
         List of validated Event instances.
     """
-    return [
-        event
-        for item in raw
-        if (event := _parse_event(item, strict=strict)) is not None
-    ]
+    return [event for item in raw if (event := _parse_event(item, strict=strict)) is not None]
 
 
 def _parse_event(item: object, *, strict: bool) -> Event | None:
@@ -230,8 +357,8 @@ class EventClient:
     API returns a nextUrl to continue from the last position.
 
     Attributes:
-        username: Chaturbate username for the event feed.
-        token: API token for authentication.
+        username: Chaturbate username parsed from the Events URL.
+        token: API token parsed from the Events URL.
         config: Client configuration instance.
         base_url: API endpoint base URL.
         session: Active HTTP session (None until context entry).
@@ -239,7 +366,9 @@ class EventClient:
     Example:
         Basic polling loop::
 
-            async with EventClient("username", "token") as client:
+            async with EventClient(
+                "https://eventsapi.chaturbate.com/events/username/token/"
+            ) as client:
                 async for event in client:
                     print(f"Received {event.type}: {event.id}")
 
@@ -249,8 +378,14 @@ class EventClient:
 
             limiter = AsyncLimiter(max_rate=2000, time_period=60)
             async with (
-                EventClient("user1", "token1", rate_limiter=limiter) as c1,
-                EventClient("user2", "token2", rate_limiter=limiter) as c2,
+                EventClient(
+                    "https://eventsapi.chaturbate.com/events/user1/token1/",
+                    rate_limiter=limiter,
+                ) as c1,
+                EventClient(
+                    "https://eventsapi.chaturbate.com/events/user2/token2/",
+                    rate_limiter=limiter,
+                ) as c2,
             ):
                 # Both clients share the same rate limit pool
                 pass
@@ -271,10 +406,13 @@ class EventClient:
         "username",
     )
 
+    base_url: str
+    username: str
+    token: str
+
     def __init__(
         self,
-        username: str,
-        token: str,
+        events_url: str,
         *,
         config: ClientConfig | None = None,
         rate_limiter: AsyncLimiter | None = None,
@@ -282,40 +420,20 @@ class EventClient:
         """Initialize event client with credentials and configuration.
 
         Args:
-            username: Chaturbate username associated with the event feed.
-            token: API token generated for the username.
+            events_url: Full Events API URL provided by upstream, for
+                example ``https://eventsapi.chaturbate.com/events/<username>/<token>/``.
             config: Optional client configuration overrides.
             rate_limiter: Optional shared rate limiter to coordinate calls
                 across multiple clients.
 
         Raises:
-            AuthError: If username or token is empty or contains whitespace.
-        """
-        if not username or username != username.strip():
-            msg = (
-                "Username must not be empty or contain leading/trailing "
-                "whitespace. Provide a valid Chaturbate username."
-            )
-            raise AuthError(msg)
-        if not token or token != token.strip():
-            msg = (
-                "Token must not be empty or contain leading/trailing "
-                "whitespace. Generate a valid token at "
-                "https://chaturbate.com/statsapi/authtoken/"
-            )
-            raise AuthError(msg)
-
-        self.username: str = username
-        self.token: str = token
+            AuthError: If events_url is malformed or has invalid credentials.
+        """  # noqa: DOC502
+        self.base_url, self.username, self.token = _parse_events_url(events_url)
         self.config: ClientConfig = config or ClientConfig()
-        self.base_url: str = (
-            TESTBED_URL if self.config.use_testbed else BASE_URL
-        )
         parsed_base = urlparse(self.base_url)
         if parsed_base.scheme and parsed_base.netloc:
-            self._base_origin: str = (
-                f"{parsed_base.scheme}://{parsed_base.netloc}"
-            )
+            self._base_origin: str = f"{parsed_base.scheme}://{parsed_base.netloc}"
         else:
             self._base_origin = self.base_url
         self.session: ClientSession | None = None
@@ -333,10 +451,7 @@ class EventClient:
         Returns:
             Masked representation revealing only limited token characters.
         """
-        return (
-            f"EventClient(username='{self.username}', "
-            f"token='{_mask_token(self.token)}')"
-        )
+        return f"EventClient(username='{self.username}', token='{_mask_token(self.token)}')"
 
     async def __aenter__(self) -> Self:
         """Initialize HTTP session on context entry.
@@ -350,9 +465,7 @@ class EventClient:
         try:
             if self.session is None:
                 self.session = ClientSession(
-                    timeout=ClientTimeout(
-                        total=self.config.timeout + SESSION_TIMEOUT_BUFFER
-                    ),
+                    timeout=ClientTimeout(total=self.config.timeout + SESSION_TIMEOUT_BUFFER),
                 )
         except (ClientError, OSError, TimeoutError) as e:
             await self.close()
@@ -397,9 +510,7 @@ class EventClient:
         Returns:
             Delay in seconds before the next retry.
         """
-        sleep_seconds = self.config.retry_backoff * (
-            self.config.retry_factor ** (attempt_num - 1)
-        )
+        sleep_seconds = self.config.retry_backoff * (self.config.retry_factor ** (attempt_num - 1))
         return min(sleep_seconds, self.config.retry_max_delay)
 
     async def _perform_request_attempt(self, url: str) -> tuple[int, str]:
@@ -457,18 +568,10 @@ class EventClient:
         msg = f"Failed to fetch events after {attempts_made} {attempt_label}."
 
         # Unwrap _TransientError if that was the cause to avoid noise.
-        cause = (
-            None
-            if isinstance(original_exception, _TransientError)
-            else original_exception
-        )
+        cause = None if isinstance(original_exception, _TransientError) else original_exception
 
-        status_code: int | None = getattr(
-            original_exception, "status_code", None
-        )
-        response_text: str | None = getattr(
-            original_exception, "response_text", None
-        )
+        status_code: int | None = getattr(original_exception, "status_code", None)
+        response_text: str | None = getattr(original_exception, "response_text", None)
 
         if status_code is not None:
             raise build_http_error(
@@ -496,10 +599,7 @@ class EventClient:
             EventsError: If the client is not initialized or the request fails.
         """
         if self.session is None:
-            msg = (
-                "Client not initialized. Use 'async with EventClient(...)'"
-                " as a context manager."
-            )
+            msg = "Client not initialized. Use 'async with EventClient(...)' as a context manager."
             raise EventsError(msg)
 
         attempts_made = 0
@@ -529,10 +629,7 @@ class EventClient:
                         return await self._perform_request_attempt(url)
                 except retriable_exc_types as exc:
                     if attempts_made < self.config.retry_attempts:
-                        msg = (
-                            "Attempt %d/%d failed for user %s: %r. "
-                            "Retrying in %.2fs..."
-                        )
+                        msg = "Attempt %d/%d failed for user %s: %r. Retrying in %.2fs..."
                         logger.warning(
                             msg,
                             attempts_made,
@@ -623,10 +720,7 @@ class EventClient:
             absolute = urljoin(base_for_join, stripped)
             return absolute, urlparse(absolute)
         if not parsed.scheme and (parsed.netloc or stripped.startswith("//")):
-            scheme = (
-                urlparse(self._base_origin).scheme
-                or urlparse(self.base_url).scheme
-            )
+            scheme = urlparse(self._base_origin).scheme or urlparse(self.base_url).scheme
             absolute = f"{scheme}:{stripped}"
             return absolute, urlparse(absolute)
         return stripped, parsed
@@ -656,9 +750,7 @@ class EventClient:
         if next_url is None:
             return None
 
-        invalid_next_url_msg = (
-            "Invalid API response: 'nextUrl' must be a non-empty string."
-        )
+        invalid_next_url_msg = "Invalid API response: 'nextUrl' must be a non-empty string."
 
         if not isinstance(next_url, str):
             logger.error(
@@ -728,10 +820,7 @@ class EventClient:
 
         data = cast("dict[str, object]", data_obj)
         status_msg = data.get("status")
-        if not (
-            isinstance(status_msg, str)
-            and TIMEOUT_STATUS_MESSAGE in status_msg.lower()
-        ):
+        if not (isinstance(status_msg, str) and TIMEOUT_STATUS_MESSAGE in status_msg.lower()):
             return None
 
         next_url = data.get("nextUrl")
@@ -772,8 +861,7 @@ class EventClient:
 
         if not isinstance(data_obj, dict):
             msg = (
-                "Invalid API response format: expected JSON object, "
-                f"got {type(data_obj).__name__}."
+                f"Invalid API response format: expected JSON object, got {type(data_obj).__name__}."
             )
             raise EventsError(
                 msg,
@@ -880,6 +968,4 @@ class EventClient:
                 try:
                     await session.close()
                 except (ClientError, OSError, RuntimeError) as e:
-                    logger.warning(
-                        "Error closing session: %s", e, exc_info=True
-                    )
+                    logger.warning("Error closing session: %s", e, exc_info=True)

--- a/src/cb_events/config.py
+++ b/src/cb_events/config.py
@@ -13,7 +13,10 @@ Example:
             retry_attempts=5,
             strict_validation=False,
         )
-        async with EventClient("user", "token", config=config) as client:
+        async with EventClient(
+            "https://eventsapi.chaturbate.com/events/user/token/",
+            config=config,
+        ) as client:
             async for event in client:
                 print(event)
 """
@@ -27,14 +30,12 @@ from typing_extensions import Self
 class ClientConfig(BaseModel):
     """Immutable configuration for EventClient behavior.
 
-    Controls timeouts, retry logic, validation strictness, and API endpoint
-    selection.
+    Controls timeouts, retry logic, and validation strictness.
 
     Example:
         Lenient configuration for development::
 
             config = ClientConfig(
-                use_testbed=True,
                 strict_validation=False,
                 retry_attempts=3,
             )
@@ -48,9 +49,6 @@ class ClientConfig(BaseModel):
 
     timeout: int = Field(default=10, gt=0)
     """Server long-poll timeout in seconds."""
-
-    use_testbed: bool = False
-    """Use the testbed API instead of production."""
 
     strict_validation: bool = False
     """Raise on invalid events vs. skip and log."""

--- a/src/cb_events/exceptions.py
+++ b/src/cb_events/exceptions.py
@@ -15,7 +15,9 @@ Example:
         from cb_events import EventClient, AuthError, EventsError
 
         try:
-            async with EventClient("user", "token") as client:
+            async with EventClient(
+                "https://eventsapi.chaturbate.com/events/user/token/"
+            ) as client:
                 async for event in client:
                     pass
         except AuthError as e:
@@ -106,9 +108,7 @@ class EventsError(Exception):
         super().__init__(message)
         self.status_code = status_code
         self.response_text = (
-            truncate_text(response_text)
-            if response_text is not None
-            else response_text
+            truncate_text(response_text) if response_text is not None else response_text
         )
 
     @override
@@ -136,7 +136,9 @@ class AuthError(EventsError):
         Handling authentication errors::
 
             try:
-                async with EventClient("user", "invalid_token") as client:
+                async with EventClient(
+                    "https://eventsapi.chaturbate.com/events/user/invalid_token/"
+                ) as client:
                     await client.poll()
             except AuthError:
                 print("Invalid credentials - regenerate token")

--- a/src/cb_events/models.py
+++ b/src/cb_events/models.py
@@ -325,9 +325,7 @@ class Event(BaseEventModel):
             return cast("str | None", cached)
         value: object | None = self.data.get("broadcaster")
         if not isinstance(value, str) or not value:
-            logger.warning(
-                "Missing or invalid broadcaster in event %s", self.id
-            )
+            logger.warning("Missing or invalid broadcaster in event %s", self.id)
             result = None
         else:
             result = value
@@ -397,8 +395,7 @@ class Event(BaseEventModel):
             result = loader(payload)
         except ValidationError as exc:
             fields: set[str] = {
-                ".".join(str(p) for p in e.get("loc", ())) or key
-                for e in exc.errors()
+                ".".join(str(p) for p in e.get("loc", ())) or key for e in exc.errors()
             }
             logger.warning(
                 "Invalid %s in event %s (invalid fields: %s)",

--- a/src/cb_events/router.py
+++ b/src/cb_events/router.py
@@ -133,9 +133,7 @@ class Router:
         """Initialize router with an empty handler registry."""
         self._handlers: dict[EventType | None, list[HandlerFunc]] = {}
 
-    def _register(
-        self, key: EventType | None, func: HandlerFunc
-    ) -> HandlerFunc:
+    def _register(self, key: EventType | None, func: HandlerFunc) -> HandlerFunc:
         """Validate and register a handler function.
 
         Args:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -13,12 +13,13 @@ from cb_events.client import (
     _mask_url,
     _parse_events,
 )
+from tests.helpers import make_events_url
 
 
 def test_token_masking_in_repr() -> None:
     """Token should be fully masked in repr."""
     full_token = "secret_token_1234"
-    client = EventClient("user", full_token)
+    client = EventClient(make_events_url("user", full_token))
     repr_str = str(client)
 
     assert full_token not in repr_str
@@ -26,30 +27,38 @@ def test_token_masking_in_repr() -> None:
 
 
 @pytest.mark.parametrize(
-    ("username", "token", "message"),
+    ("events_url", "message"),
     [
-        ("", "token", "Username must not be empty or contain"),
-        (" user ", "token", "Username must not be empty or contain"),
-        ("user", "", "Token must not be empty or contain"),
-        ("user", " token ", "Token must not be empty or contain"),
+        ("", "Events URL must not be empty or contain"),
+        (
+            "http://eventsapi.chaturbate.com/events/user/token/",
+            "Events URL must use https",
+        ),
+        (
+            "https://example.com/events/user/token/",
+            "Events URL host is not supported",
+        ),
+        (
+            "https://eventsapi.chaturbate.com/events/user/",
+            "Events URL must match",
+        ),
+        (
+            "https://eventsapi.chaturbate.com/events/user/token/?timeout=10",
+            "must not include query parameters",
+        ),
     ],
 )
-def test_reject_invalid_credentials(
-    username: str, token: str, message: str
-) -> None:
-    """Invalid credentials should raise an ``AuthError`` with guidance."""
+def test_reject_invalid_credentials(events_url: str, message: str) -> None:
+    """Invalid URLs should raise an ``AuthError`` with guidance."""
     with pytest.raises(AuthError, match=message):
-        EventClient(username, token)
+        EventClient(events_url)
 
 
 def test_mask_url_replaces_raw_and_encoded_token() -> None:
     """_mask_url should mask both plain and percent-encoded tokens in URLs."""
     token = "super_secret_token_1234"
     encoded = quote(token, safe="")
-    url = (
-        f"https://events.testbed.cb.dev/events/user/{token}/"
-        f"?t={token}&encoded={encoded}"
-    )
+    url = f"https://events.testbed.cb.dev/events/user/{token}/?t={token}&encoded={encoded}"
 
     masked = _mask_url(url, token)
 
@@ -114,7 +123,10 @@ def test_eventclient_build_url_and_repr() -> None:
     """
     token = "super_secret_token_1234"
     username = "username"
-    client = EventClient(username, token, config=ClientConfig(use_testbed=True))
+    client = EventClient(
+        make_events_url(username, token),
+        config=ClientConfig(),
+    )
 
     url = client._build_url()
     assert quote(username, safe="") in url
@@ -127,14 +139,14 @@ def test_eventclient_build_url_and_repr() -> None:
 
 async def test_close_called_twice_does_not_raise() -> None:
     """Calling close() twice should be a no-op on the second call."""
-    client = EventClient("user", "test_token")
+    client = EventClient(make_events_url("user", "test_token"))
     await client.close()
     await client.close()
 
 
 async def test_properties_accessible_after_close() -> None:
     """Username and session state should remain accessible after close()."""
-    client = EventClient("user", "test_token")
+    client = EventClient(make_events_url("user", "test_token"))
     await client.close()
     assert client.username == "user"
     assert client.session is None
@@ -154,7 +166,7 @@ async def test_close_logs_warning_when_session_close_raises(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Errors raised by session.close() should log warnings, not propagate."""
-    client = EventClient("user", "test_token")
+    client = EventClient(make_events_url("user", "test_token"))
 
     mock_session = AsyncMock()
     mock_session.close = AsyncMock(side_effect=exc_instance)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -46,6 +46,14 @@ def test_token_masking_in_repr() -> None:
             "https://eventsapi.chaturbate.com/events/user/token/?timeout=10",
             "must not include query parameters",
         ),
+        (
+            "https://eventsapi.chaturbate.com:8443/events/user/token/",
+            "must not include a custom port",
+        ),
+        (
+            "https://eventsapi.chaturbate.com:abc/events/user/token/",
+            "must not include a custom port",
+        ),
     ],
 )
 def test_reject_invalid_credentials(events_url: str, message: str) -> None:

--- a/tests/client/test_client_internal.py
+++ b/tests/client/test_client_internal.py
@@ -10,11 +10,12 @@ from aioresponses import aioresponses
 
 from cb_events import ClientConfig, EventClient, EventsError
 from cb_events.client import TESTBED_URL
+from tests.helpers import make_events_url
 
 
 async def test_request_raises_when_client_not_initialized() -> None:
     """_request should fail fast when called outside context manager."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     with pytest.raises(EventsError, match="Client not initialized"):
         await client._request("https://events.testbed.cb.dev/events")
@@ -22,12 +23,10 @@ async def test_request_raises_when_client_not_initialized() -> None:
 
 async def test_perform_request_attempt_raises_when_session_missing() -> None:
     """_perform_request_attempt should reject missing sessions."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     with pytest.raises(EventsError, match="session unexpectedly unavailable"):
-        await client._perform_request_attempt(
-            "https://events.testbed.cb.dev/events"
-        )
+        await client._perform_request_attempt("https://events.testbed.cb.dev/events")
 
 
 async def test_aenter_wraps_session_creation_failures(
@@ -40,7 +39,7 @@ async def test_aenter_wraps_session_creation_failures(
         raise OSError(msg)
 
     monkeypatch.setattr("cb_events.client.ClientSession", _boom)
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     with pytest.raises(EventsError, match="Failed to create HTTP session"):
         async with client:
@@ -49,13 +48,13 @@ async def test_aenter_wraps_session_creation_failures(
 
 def test_extract_next_url_timeout_payload_not_mapping() -> None:
     """Non-object timeout payloads should return None."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
     assert client._extract_next_url_from_timeout("[]") is None
 
 
 def test_extract_next_url_timeout_status_not_string() -> None:
     """Timeout payloads with non-string status should return None."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
     payload = json.dumps({
         "status": 123,
         "nextUrl": "https://events.testbed.cb.dev/events/next",
@@ -65,7 +64,7 @@ def test_extract_next_url_timeout_status_not_string() -> None:
 
 def test_extract_next_url_timeout_status_without_timeout_text() -> None:
     """Timeout parser should ignore unrelated status messages."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
     payload = json.dumps({
         "status": "ok",
         "nextUrl": "https://events.testbed.cb.dev/events/next",
@@ -75,7 +74,7 @@ def test_extract_next_url_timeout_status_without_timeout_text() -> None:
 
 def test_extract_next_url_timeout_missing_next_url() -> None:
     """Timeout parser should return None when nextUrl is absent."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
     payload = json.dumps({"status": "waited too long for events"})
     assert client._extract_next_url_from_timeout(payload) is None
 
@@ -84,7 +83,7 @@ def test_extract_next_url_timeout_when_validator_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If nextUrl validator returns None, timeout parser should return None."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     def _always_none(
         _self: EventClient,
@@ -109,7 +108,7 @@ def test_extract_next_url_timeout_when_validator_returns_none(
 
 def test_parse_json_response_rejects_non_object() -> None:
     """Top-level JSON arrays should be rejected."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     with pytest.raises(EventsError, match="expected JSON object"):
         client._parse_json_response("[]")
@@ -117,7 +116,7 @@ def test_parse_json_response_rejects_non_object() -> None:
 
 def test_parse_json_response_allows_missing_events_key() -> None:
     """Missing events key should be treated as an empty event list."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     events = client._parse_json_response('{"nextUrl": null}')
     assert events == []
@@ -127,7 +126,7 @@ def test_parse_json_response_debug_logs_event_count(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Debug logging should include the number of parsed events."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
     payload = json.dumps({
         "events": [{"method": "tip", "id": "evt-1", "object": {}}],
         "nextUrl": None,
@@ -146,7 +145,8 @@ async def test_poll_debug_logs_masked_url(
 ) -> None:
     """Poll should emit a debug log with a masked URL when debug is enabled."""
     client = EventClient(
-        "test_user", "secret_token_123", config=ClientConfig(use_testbed=True)
+        make_events_url("test_user", "secret_token_123"),
+        config=ClientConfig(),
     )
 
     request_url = f"{TESTBED_URL}/test_user/secret_token_123/?timeout=10"
@@ -160,9 +160,7 @@ async def test_poll_debug_logs_masked_url(
         events = await client.poll()
 
     assert events == []
-    assert (
-        "Polling https://events.testbed.cb.dev/events/test_user/" in caplog.text
-    )
+    assert "Polling https://events.testbed.cb.dev/events/test_user/" in caplog.text
     assert "secret_token_123" not in caplog.text
 
 
@@ -170,7 +168,7 @@ async def test_request_non_retriable_error_is_propagated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Non-retriable exceptions should bypass retry wrapping."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     async def _boom(_self: EventClient, _url: str) -> tuple[int, str]:
         await asyncio.sleep(0)
@@ -188,7 +186,7 @@ async def test_request_raises_unexpected_error_when_retry_context_is_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Empty retry contexts should trigger the defensive fallback error."""
-    client = EventClient("user", "token")
+    client = EventClient(make_events_url("user", "token"))
 
     class _EmptyRetryContext:
         def __aiter__(self) -> _EmptyRetryContext:
@@ -206,7 +204,5 @@ async def test_request_raises_unexpected_error_when_retry_context_is_empty(
     )
 
     async with client:
-        with pytest.raises(
-            EventsError, match="Unexpected error in request loop"
-        ):
+        with pytest.raises(EventsError, match="Unexpected error in request loop"):
             await client._request("https://events.testbed.cb.dev/events")

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -10,7 +10,6 @@ def test_default_configuration() -> None:
     """Default config should have sensible retry and timeout values."""
     config = ClientConfig()
 
-    assert config.use_testbed is False
     assert config.timeout == 10
     assert config.retry_attempts == 8
 
@@ -18,7 +17,6 @@ def test_default_configuration() -> None:
 def test_custom_configuration() -> None:
     """Config should accept custom values for all parameters."""
     config = ClientConfig(
-        use_testbed=True,
         timeout=60,
         retry_attempts=5,
         retry_backoff=2.0,
@@ -26,7 +24,6 @@ def test_custom_configuration() -> None:
         retry_max_delay=120.0,
     )
 
-    assert config.use_testbed is True
     assert config.timeout == 60
     assert config.retry_attempts == 5
     assert config.retry_backoff == pytest.approx(2.0)
@@ -57,9 +54,7 @@ def test_reject_non_positive_values(invalid_kwargs: dict[str, int]) -> None:
 
 def test_reject_max_delay_less_than_backoff() -> None:
     """Max delay must be greater than or equal to backoff."""
-    with pytest.raises(
-        ValidationError, match=r"retry_max_delay .* must be >= retry_backoff"
-    ):
+    with pytest.raises(ValidationError, match=r"retry_max_delay .* must be >= retry_backoff"):
         ClientConfig(retry_backoff=10.0, retry_max_delay=5.0)
 
 

--- a/tests/client/test_polling_concurrency.py
+++ b/tests/client/test_polling_concurrency.py
@@ -7,7 +7,7 @@ from aioresponses import aioresponses
 
 from cb_events import EventType
 from tests.conftest import EventClientFactory
-from tests.helpers import TESTBED_BASE_URL, make_event, make_response
+from tests.helpers import TESTBED_POLL_URL, make_event, make_response
 
 
 async def test_concurrent_polls_serialized(
@@ -16,20 +16,14 @@ async def test_concurrent_polls_serialized(
     testbed_url_pattern: re.Pattern[str],
 ) -> None:
     """Concurrent ``poll`` calls should run serially via the internal lock."""
-    base_url = TESTBED_BASE_URL
+    base_url = TESTBED_POLL_URL
     next_url_1 = f"{base_url}&next=1"
     next_url_2 = f"{base_url}&next=2"
 
     responses = [
-        make_response(
-            [make_event(EventType.TIP, event_id="1")], next_url=next_url_1
-        ),
-        make_response(
-            [make_event(EventType.TIP, event_id="2")], next_url=next_url_2
-        ),
-        make_response(
-            [make_event(EventType.TIP, event_id="3")], next_url=base_url
-        ),
+        make_response([make_event(EventType.TIP, event_id="1")], next_url=next_url_1),
+        make_response([make_event(EventType.TIP, event_id="2")], next_url=next_url_2),
+        make_response([make_event(EventType.TIP, event_id="3")], next_url=base_url),
     ]
 
     aioresponses_mock.get(testbed_url_pattern, payload=responses[0])
@@ -37,13 +31,8 @@ async def test_concurrent_polls_serialized(
     aioresponses_mock.get(next_url_2, payload=responses[2])
 
     async with event_client_factory() as client:
-        results = await asyncio.gather(
-            client.poll(), client.poll(), client.poll()
-        )
+        results = await asyncio.gather(client.poll(), client.poll(), client.poll())
 
     assert len(results) == 3
-    assert all(
-        len(events) == 1 and events[0].type == EventType.TIP
-        for events in results
-    )
+    assert all(len(events) == 1 and events[0].type == EventType.TIP for events in results)
     assert [events[0].id for events in results] == ["1", "2", "3"]

--- a/tests/client/test_polling_errors.py
+++ b/tests/client/test_polling_errors.py
@@ -35,19 +35,15 @@ async def test_rate_limit_error(
     testbed_url_pattern: re.Pattern[str],
 ) -> None:
     """HTTP 429 responses should surface as :class:`RateLimitError`."""
-    aioresponses_mock.get(
-        testbed_url_pattern, status=429, repeat=True, body="Rate limit exceeded"
-    )
-    config = ClientConfig(use_testbed=True, retry_attempts=1, retry_backoff=0.0)
+    aioresponses_mock.get(testbed_url_pattern, status=429, repeat=True, body="Rate limit exceeded")
+    config = ClientConfig(retry_attempts=1, retry_backoff=0.0)
 
     async with event_client_factory(config=config) as client:
         with pytest.raises(RateLimitError, match=r"HTTP 429"):
             await client.poll()
 
 
-@pytest.mark.parametrize(
-    "status_code", [500, 502, 503, 504, 521, 522, 523, 524]
-)
+@pytest.mark.parametrize("status_code", [500, 502, 503, 504, 521, 522, 523, 524])
 async def test_server_error_after_retry_exhaustion(
     status_code: int,
     event_client_factory: EventClientFactory,
@@ -56,7 +52,7 @@ async def test_server_error_after_retry_exhaustion(
 ) -> None:
     """Retryable server failures should raise `ServerError` after retries."""
     aioresponses_mock.get(testbed_url_pattern, status=status_code, repeat=True)
-    config = ClientConfig(use_testbed=True, retry_attempts=1, retry_backoff=0.0)
+    config = ClientConfig(retry_attempts=1, retry_backoff=0.0)
 
     async with event_client_factory(config=config) as client:
         with pytest.raises(ServerError, match=rf"HTTP {status_code}"):
@@ -69,9 +65,7 @@ async def test_invalid_json_response(
     testbed_url_pattern: re.Pattern[str],
 ) -> None:
     """Invalid JSON payloads should raise :class:`EventsError`."""
-    aioresponses_mock.get(
-        testbed_url_pattern, status=200, body="Not valid JSON"
-    )
+    aioresponses_mock.get(testbed_url_pattern, status=200, body="Not valid JSON")
 
     async with event_client_factory() as client:
         with pytest.raises(EventsError, match="Invalid JSON response"):
@@ -84,9 +78,7 @@ async def test_timeout_payload_not_mapping(
     testbed_url_pattern: re.Pattern[str],
 ) -> None:
     """Timeout payloads that are not JSON objects should raise EventsError."""
-    aioresponses_mock.get(
-        testbed_url_pattern, status=400, payload=["unexpected"]
-    )
+    aioresponses_mock.get(testbed_url_pattern, status=400, payload=["unexpected"])
 
     async with event_client_factory() as client:
         with pytest.raises(EventsError, match="HTTP 400"):
@@ -118,12 +110,10 @@ async def test_network_error_wrapped(
         exception=ClientError("Connection reset by peer"),
         repeat=True,
     )
-    config = ClientConfig(use_testbed=True, retry_attempts=1, retry_backoff=0.0)
+    config = ClientConfig(retry_attempts=1, retry_backoff=0.0)
 
     async with event_client_factory(config=config) as client:
-        with pytest.raises(
-            EventsError, match=r"Failed to fetch events after 1 attempt"
-        ):
+        with pytest.raises(EventsError, match=r"Failed to fetch events after 1 attempt"):
             await client.poll()
 
 
@@ -159,7 +149,6 @@ async def test_network_errors_exhaust_retries(
     """Different network error types should exhaust retries properly."""
     aioresponses_mock.get(testbed_url_pattern, exception=exc, repeat=True)
     config = ClientConfig(
-        use_testbed=True,
         retry_attempts=retry_attempts,
         retry_backoff=retry_backoff,
         retry_factor=retry_factor,

--- a/tests/client/test_polling_next_url.py
+++ b/tests/client/test_polling_next_url.py
@@ -17,16 +17,10 @@ async def test_next_url_followed_after_timeout(
     testbed_url_pattern: re.Pattern[str],
 ) -> None:
     """When a timeout response returns a base-host ``nextUrl``, follow it."""
-    timeout_response = make_timeout_payload(
-        "https://events.testbed.cb.dev/events/next_batch_token"
-    )
-    aioresponses_mock.get(
-        testbed_url_pattern, status=400, payload=timeout_response
-    )
+    timeout_response = make_timeout_payload("https://events.testbed.cb.dev/events/next_batch_token")
+    aioresponses_mock.get(testbed_url_pattern, status=400, payload=timeout_response)
 
-    next_url_pattern = re.compile(
-        r"https://events\.testbed\.cb\.dev/events/next_batch_token"
-    )
+    next_url_pattern = re.compile(r"https://events\.testbed\.cb\.dev/events/next_batch_token")
     success_response = make_response([make_event(EventType.TIP, event_id="1")])
     aioresponses_mock.get(next_url_pattern, payload=success_response)
 
@@ -45,12 +39,8 @@ async def test_disallowed_next_url_host_raises(
     testbed_url_pattern: re.Pattern[str],
 ) -> None:
     """Timeout responses with off-host nextUrl should raise an error."""
-    timeout_response = make_timeout_payload(
-        "https://evil.example.com/events/next_batch_token"
-    )
-    aioresponses_mock.get(
-        testbed_url_pattern, status=400, payload=timeout_response
-    )
+    timeout_response = make_timeout_payload("https://evil.example.com/events/next_batch_token")
+    aioresponses_mock.get(testbed_url_pattern, status=400, payload=timeout_response)
 
     async with event_client_factory() as client:
         with pytest.raises(EventsError, match=r"Invalid nextUrl host"):
@@ -66,8 +56,7 @@ async def test_relative_next_url_resolved_to_absolute(
     relative_next = "/events/test_user/test_token/?timeout=10&next=relative"
     initial_response = make_response([], next_url=relative_next)
     next_absolute = (
-        "https://events.testbed.cb.dev/events/"
-        "test_user/test_token/?timeout=10&next=relative"
+        "https://events.testbed.cb.dev/events/test_user/test_token/?timeout=10&next=relative"
     )
     success_response = make_response([make_event(EventType.TIP, event_id="1")])
 

--- a/tests/client/test_polling_success.py
+++ b/tests/client/test_polling_success.py
@@ -102,7 +102,7 @@ async def test_strict_validation_raises_on_invalid_event(
         "nextUrl": None,
     }
     aioresponses_mock.get(testbed_url_pattern, payload=response)
-    config = ClientConfig(use_testbed=True, strict_validation=True)
+    config = ClientConfig(strict_validation=True)
 
     async with event_client_factory(config=config) as client:
         with pytest.raises(ValidationError):
@@ -123,7 +123,7 @@ async def test_lenient_validation_skips_invalid_events(
         "nextUrl": None,
     }
     aioresponses_mock.get(testbed_url_pattern, payload=response)
-    config = ClientConfig(use_testbed=True, strict_validation=False)
+    config = ClientConfig(strict_validation=False)
 
     async with event_client_factory(config=config) as client:
         events = await client.poll()

--- a/tests/client/test_request_retry.py
+++ b/tests/client/test_request_retry.py
@@ -18,7 +18,6 @@ async def test_exponential_backoff_schedule_and_clamping(
     stamina.set_testing(True, attempts=4)
 
     config = ClientConfig(
-        use_testbed=True,
         retry_attempts=10,
         retry_backoff=0.01,
         retry_factor=2.0,
@@ -46,7 +45,6 @@ async def test_exception_retries_until_success_with_testing_cap(
     stamina.set_testing(True, attempts=3)
 
     config = ClientConfig(
-        use_testbed=True,
         retry_attempts=10,
         retry_backoff=0.01,
         retry_factor=2.0,
@@ -79,7 +77,6 @@ async def test_testing_mode_caps_attempts(
     stamina.set_testing(True, attempts=2)
 
     config = ClientConfig(
-        use_testbed=True,
         retry_attempts=10,
         retry_backoff=0.01,
         retry_factor=3.0,
@@ -104,7 +101,7 @@ async def test_retries_on_retry_status_codes_then_succeeds(
     aioresponses_mock.get(testbed_url_pattern, status=502)
     aioresponses_mock.get(testbed_url_pattern, payload=success_response)
 
-    config = ClientConfig(use_testbed=True, retry_attempts=2, retry_backoff=0.0)
+    config = ClientConfig(retry_attempts=2, retry_backoff=0.0)
     async with event_client_factory(config=config) as client:
         events = await client.poll()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,8 +82,8 @@ def event_client_factory(credentials: tuple[str, str]) -> EventClientFactory:
             msg = "Provide either `config` or keyword overrides, not both."
             raise ValueError(msg)
 
-        client_username = username_override or username
-        client_token = token_override or token
+        client_username = username if username_override is None else username_override
+        client_token = token if token_override is None else token_override
         events_url = make_events_url(
             client_username,
             client_token,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from cb_events import (
     EventClient,
     Router,
 )
+from tests.helpers import make_events_url
 
 
 class EventClientFactory(Protocol):
@@ -83,14 +84,17 @@ def event_client_factory(credentials: tuple[str, str]) -> EventClientFactory:
 
         client_username = username_override or username
         client_token = token_override or token
+        events_url = make_events_url(
+            client_username,
+            client_token,
+            use_testbed=use_testbed,
+        )
 
         if config is None:
-            config_kwargs = {"use_testbed": use_testbed, **config_overrides}
+            config_kwargs = {**config_overrides}
             config = ClientConfig.model_validate(config_kwargs)
 
-        async with EventClient(
-            client_username, client_token, config=config
-        ) as client:
+        async with EventClient(events_url, config=config) as client:
             yield client
 
     return _factory

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,9 +11,24 @@ if TYPE_CHECKING:
 
 CORE_EVENT_TYPES: tuple[EventType, ...] = tuple(EventType)
 
-TESTBED_BASE_URL = (
-    "https://events.testbed.cb.dev/events/test_user/test_token/?timeout=10"
-)
+TESTBED_EVENTS_URL = "https://events.testbed.cb.dev/events/test_user/test_token/"
+
+TESTBED_POLL_URL = "https://events.testbed.cb.dev/events/test_user/test_token/?timeout=10"
+
+
+def make_events_url(
+    username: str,
+    token: str,
+    *,
+    use_testbed: bool = True,
+) -> str:
+    """Build a combined upstream Events URL for a username/token pair.
+
+    Returns:
+        A string URL in the format expected by ``EventClient``.
+    """
+    host = "events.testbed.cb.dev" if use_testbed else "eventsapi.chaturbate.com"
+    return f"https://{host}/events/{username}/{token}/"
 
 
 def make_event(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -29,9 +29,7 @@ def test_events_error_properties_and_str(
     expected_str: str,
 ) -> None:
     """EventsError should expose message and HTTP metadata fields."""
-    error = EventsError(
-        message, status_code=status_code, response_text=response_text
-    )
+    error = EventsError(message, status_code=status_code, response_text=response_text)
 
     assert str(error) == expected_str
     assert error.status_code == status_code
@@ -75,9 +73,7 @@ def test_build_http_error_returns_specific_subclasses(
     assert error.status_code == status_code
 
 
-def test_build_http_error_returns_base_http_status_error_for_other_codes() -> (
-    None
-):
+def test_build_http_error_returns_base_http_status_error_for_other_codes() -> None:
     """Unexpected statuses should fall back to HttpStatusError."""
     error = build_http_error("Request failed", status_code=302)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,7 +18,7 @@ from cb_events import (
     __version__,
 )
 from tests.conftest import EventClientFactory
-from tests.helpers import make_event, make_response
+from tests.helpers import make_event, make_events_url, make_response
 
 pytestmark = [pytest.mark.e2e]
 
@@ -66,7 +66,7 @@ async def test_client_router_workflow(
 
 async def test_client_context_manager_lifecycle() -> None:
     """Context manager should open and close the internal session."""
-    client = EventClient("test_user", "test_token")
+    client = EventClient(make_events_url("test_user", "test_token"))
     assert client.session is None
 
     async with client:
@@ -96,22 +96,13 @@ def test_version_attribute() -> None:
 @pytest.mark.slow
 @pytest.mark.live
 @pytest.mark.skipif(
-    not (
-        os.getenv("CB_RUN_LIVE_TESTS") == "1"
-        and os.getenv("CB_USERNAME")
-        and os.getenv("CB_TOKEN")
-    ),
-    reason=(
-        "Set CB_RUN_LIVE_TESTS=1, CB_USERNAME, and CB_TOKEN to run live "
-        "testbed test"
-    ),
+    not (os.getenv("CB_RUN_LIVE_TESTS") == "1" and os.getenv("CB_EVENTS_URL")),
+    reason=("Set CB_RUN_LIVE_TESTS=1 and CB_EVENTS_URL to run live testbed test"),
 )
 async def test_live_testbed_polling() -> None:
     """Test against the live testbed using environment credentials."""
-    username = os.environ["CB_USERNAME"]
-    token = os.environ["CB_TOKEN"]
+    events_url = os.environ["CB_EVENTS_URL"]
     config = ClientConfig(
-        use_testbed=True,
         strict_validation=False,
         retry_attempts=3,
         retry_backoff=1.0,
@@ -119,7 +110,10 @@ async def test_live_testbed_polling() -> None:
         retry_max_delay=5.0,
     )
 
-    async with EventClient(username, token, config=config) as client:
+    async with EventClient(
+        events_url,
+        config=config,
+    ) as client:
         events = await client.poll()
 
     assert isinstance(events, list)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,16 +24,17 @@ from tests.helpers import make_event, make_events_url, make_response
 pytestmark = [pytest.mark.e2e]
 
 
-def is_testbed_url(url: str | None) -> bool:
-    """Return True when URL points to an explicit testbed endpoint."""
+def is_events_url(url: str | None) -> bool:
+    """Return True when URL points to a supported Events API endpoint."""
     if not url:
         return False
     parsed = urlparse(url)
     if parsed.scheme != "https":
         return False
+    allowed_hosts = {"eventsapi.chaturbate.com", "events.testbed.cb.dev"}
     hostname = (parsed.hostname or "").lower()
     path = parsed.path.lower()
-    return hostname == "events.testbed.cb.dev" or "testbed" in hostname or "testbed" in path
+    return hostname in allowed_hosts and path.startswith("/events/")
 
 
 async def test_client_router_workflow(
@@ -109,11 +110,11 @@ def test_version_attribute() -> None:
 @pytest.mark.slow
 @pytest.mark.live
 @pytest.mark.skipif(
-    not (os.getenv("CB_RUN_LIVE_TESTS") == "1" and is_testbed_url(os.getenv("CB_EVENTS_URL"))),
-    reason=("Set CB_RUN_LIVE_TESTS=1 and CB_EVENTS_URL to an HTTPS testbed URL"),
+    not (os.getenv("CB_RUN_LIVE_TESTS") == "1" and is_events_url(os.getenv("CB_EVENTS_URL"))),
+    reason=("Set CB_RUN_LIVE_TESTS=1 and CB_EVENTS_URL to an Events API URL"),
 )
-async def test_live_testbed_polling() -> None:
-    """Test against the live testbed using environment credentials."""
+async def test_live_polling() -> None:
+    """Test against the live service."""
     events_url = os.environ["CB_EVENTS_URL"]
     config = ClientConfig(
         strict_validation=False,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import re
 from importlib.metadata import version
+from urllib.parse import urlparse
 
 import pytest
 from aioresponses import aioresponses
@@ -21,6 +22,18 @@ from tests.conftest import EventClientFactory
 from tests.helpers import make_event, make_events_url, make_response
 
 pytestmark = [pytest.mark.e2e]
+
+
+def is_testbed_url(url: str | None) -> bool:
+    """Return True when URL points to an explicit testbed endpoint."""
+    if not url:
+        return False
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    hostname = (parsed.hostname or "").lower()
+    path = parsed.path.lower()
+    return hostname == "events.testbed.cb.dev" or "testbed" in hostname or "testbed" in path
 
 
 async def test_client_router_workflow(
@@ -96,8 +109,8 @@ def test_version_attribute() -> None:
 @pytest.mark.slow
 @pytest.mark.live
 @pytest.mark.skipif(
-    not (os.getenv("CB_RUN_LIVE_TESTS") == "1" and os.getenv("CB_EVENTS_URL")),
-    reason=("Set CB_RUN_LIVE_TESTS=1 and CB_EVENTS_URL to run live testbed test"),
+    not (os.getenv("CB_RUN_LIVE_TESTS") == "1" and is_testbed_url(os.getenv("CB_EVENTS_URL"))),
+    reason=("Set CB_RUN_LIVE_TESTS=1 and CB_EVENTS_URL to an HTTPS testbed URL"),
 )
 async def test_live_testbed_polling() -> None:
     """Test against the live testbed using environment credentials."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,9 +51,7 @@ def test_event_properties_parsed() -> None:
         (None, None),  # None passes through unchanged
     ],
 )
-def test_user_subgender_validator(
-    raw_subgender: str | None, expected: str | None
-) -> None:
+def test_user_subgender_validator(raw_subgender: str | None, expected: str | None) -> None:
     """Empty subgender should coerce to None while valid values pass through."""
     user = User.model_validate({"username": "u", "subgender": raw_subgender})
     assert user.subgender == expected
@@ -231,8 +229,7 @@ def test_event_property_validation_errors_logged(
     warning_records = [
         r
         for r in caplog.records
-        if r.levelname == "WARNING"
-        and f"{log_msg} in event {event_id}" in r.getMessage()
+        if r.levelname == "WARNING" and f"{log_msg} in event {event_id}" in r.getMessage()
     ]
     assert len(warning_records) == 1
 
@@ -274,8 +271,7 @@ def test_event_broadcaster_missing_returns_none(
 
     assert event.broadcaster is None
     assert any(
-        "Missing or invalid broadcaster in event evt-bcaster-missing"
-        in r.getMessage()
+        "Missing or invalid broadcaster in event evt-bcaster-missing" in r.getMessage()
         for r in caplog.records
         if r.levelname == "WARNING"
     )

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -92,9 +92,7 @@ async def test_any_handler_called_for_unmatched_type(router: Router) -> None:
     router.on(EventType.TIP)(AsyncMock())
     router.on_any()(any_handler)
 
-    follow_event = Event.model_validate(
-        make_event(EventType.FOLLOW, event_id="f")
-    )
+    follow_event = Event.model_validate(make_event(EventType.FOLLOW, event_id="f"))
     await router.dispatch(follow_event)
 
     any_handler.assert_called_once_with(follow_event)

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -305,6 +307,48 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "mypy-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.12'" },
+    { name = "pytokens", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/a8/11170031095655d36ebc6664fe0897866f6023892396900eec0e8fdc4299/black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2", size = 1866562, upload-time = "2026-03-12T03:39:58.639Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ce/9e7548d719c3248c6c2abfd555d11169457cbd584d98d179111338423790/black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b", size = 1703623, upload-time = "2026-03-12T03:40:00.347Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0a/8d17d1a9c06f88d3d030d0b1d4373c1551146e252afe4547ed601c0e697f/black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac", size = 1768388, upload-time = "2026-03-12T03:40:01.765Z" },
+    { url = "https://files.pythonhosted.org/packages/52/79/c1ee726e221c863cde5164f925bacf183dfdf0397d4e3f94889439b947b4/black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a", size = 1412969, upload-time = "2026-03-12T03:40:03.252Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a5/15c01d613f5756f68ed8f6d4ec0a1e24b82b18889fa71affd3d1f7fad058/black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a", size = 1220345, upload-time = "2026-03-12T03:40:04.892Z" },
+    { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload-time = "2026-03-12T03:40:06.248Z" },
+    { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload-time = "2026-03-12T03:40:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload-time = "2026-03-12T03:40:09.279Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/09/61e91881ca291f150cfc9eb7ba19473c2e59df28859a11a88248b5cbbc4d/black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e", size = 1413613, upload-time = "2026-03-12T03:40:10.943Z" },
+    { url = "https://files.pythonhosted.org/packages/16/73/544f23891b22e7efe4d8f812371ab85b57f6a01b2fc45e3ba2e52ba985b8/black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5", size = 1219719, upload-time = "2026-03-12T03:40:12.597Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+]
+
+[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -362,6 +406,7 @@ dev = [
     { name = "xenon" },
 ]
 docs = [
+    { name = "docstrfmt", marker = "python_full_version >= '3.12'" },
     { name = "furo", marker = "python_full_version >= '3.12'" },
     { name = "myst-parser", marker = "python_full_version >= '3.12'" },
     { name = "sphinx", marker = "python_full_version >= '3.12'" },
@@ -419,6 +464,7 @@ dev = [
     { name = "xenon", specifier = "==0.9.3" },
 ]
 docs = [
+    { name = "docstrfmt", marker = "python_full_version >= '3.12'", specifier = "==2.0.2" },
     { name = "furo", marker = "python_full_version >= '3.12'", specifier = "==2025.12.19" },
     { name = "myst-parser", marker = "python_full_version >= '3.12'", specifier = "==5.0.0" },
     { name = "sphinx", marker = "python_full_version >= '3.12'", specifier = "==9.1.0" },
@@ -778,12 +824,46 @@ wheels = [
 ]
 
 [[package]]
-name = "docutils"
-version = "0.22.4"
+name = "docstrfmt"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+dependencies = [
+    { name = "black", marker = "python_full_version >= '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "coverage", marker = "python_full_version >= '3.12'" },
+    { name = "docutils", marker = "python_full_version >= '3.12'" },
+    { name = "docutils-stubs", marker = "python_full_version >= '3.12'" },
+    { name = "libcst", marker = "python_full_version >= '3.12'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.12'" },
+    { name = "roman", marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", marker = "python_full_version >= '3.12'" },
+    { name = "tabulate", marker = "python_full_version >= '3.12'" },
+    { name = "types-docutils", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/81/94fa7aee5d6e1cbb66d0c5eb2c12ca21db8a5f39f55bb192683f14538e61/docstrfmt-2.0.2.tar.gz", hash = "sha256:086e74b03c337c9a932b2f8216aa8c93bb6576b525edfb5d754b6bac841d4166", size = 40169, upload-time = "2026-02-07T20:18:16.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d0/d8b1ac9e6cfa3d1df0a88d45364b37f582d4b02a39cb16b5161801021e7f/docstrfmt-2.0.2-py3-none-any.whl", hash = "sha256:acbff3cb00ea85a5c153355b43aeb6d40e0775cfcdbaa1dea42b333b9c8c233d", size = 39604, upload-time = "2026-02-07T20:18:14.79Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+]
+
+[[package]]
+name = "docutils-stubs"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/fb/3eda037eed8b98d6b2169e4198a8f12a03a461c4d4dc44de1a7790d0f7c7/docutils-stubs-0.0.22.tar.gz", hash = "sha256:1736d9650cfc20cff8c72582806c33a5c642694e2df9e430717e7da7e73efbdf", size = 43699, upload-time = "2022-01-02T11:13:17.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/85/10507e1011d5370b94567e4b57f93086a2476d1da73caf98dc53aa87004b/docutils_stubs-0.0.22-py3-none-any.whl", hash = "sha256:157807309de24e8c96af9a13afe207410f1fc6e5aab5d974fd6b9191f04de327", size = 87506, upload-time = "2022-01-02T11:13:15.94Z" },
 ]
 
 [[package]]
@@ -1064,6 +1144,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/a6/d07afcfdef402900229bcca795f80506b207af13a838d4d99ad45abf530c/jsonpickle-4.1.1.tar.gz", hash = "sha256:f86e18f13e2b96c1c1eede0b7b90095bbb61d99fedc14813c44dc2f361dbbae1", size = 316885, upload-time = "2025-06-02T20:36:11.57Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/73/04df8a6fa66d43a9fd45c30f283cc4afff17da671886e451d52af60bdc7e/jsonpickle-4.1.1-py3-none-any.whl", hash = "sha256:bb141da6057898aa2438ff268362b126826c812a1721e31cf08a6e142910dc91", size = 47125, upload-time = "2025-06-02T20:36:08.647Z" },
+]
+
+[[package]]
+name = "libcst"
+version = "1.8.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version == '3.12.*' or python_full_version >= '3.14'" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cd/337df968b38d94c5aabd3e1b10630f047a2b345f6e1d4456bd9fe7417537/libcst-1.8.6.tar.gz", hash = "sha256:f729c37c9317126da9475bdd06a7208eb52fcbd180a6341648b45a56b4ba708b", size = 891354, upload-time = "2025-11-03T22:33:30.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/52/97d5454dee9d014821fe0c88f3dc0e83131b97dd074a4d49537056a75475/libcst-1.8.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a20c5182af04332cc94d8520792befda06d73daf2865e6dddc5161c72ea92cb9", size = 2211698, upload-time = "2025-11-03T22:31:50.117Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a4/d1205985d378164687af3247a9c8f8bdb96278b0686ac98ab951bc6d336a/libcst-1.8.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:36473e47cb199b7e6531d653ee6ffed057de1d179301e6c67f651f3af0b499d6", size = 2093104, upload-time = "2025-11-03T22:31:52.189Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/de/1338da681b7625b51e584922576d54f1b8db8fc7ff4dc79121afc5d4d2cd/libcst-1.8.6-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:06fc56335a45d61b7c1b856bfab4587b84cfe31e9d6368f60bb3c9129d900f58", size = 2237419, upload-time = "2025-11-03T22:31:53.526Z" },
+    { url = "https://files.pythonhosted.org/packages/50/06/ee66f2d83b870534756e593d464d8b33b0914c224dff3a407e0f74dc04e0/libcst-1.8.6-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6b23d14a7fc0addd9795795763af26b185deb7c456b1e7cc4d5228e69dab5ce8", size = 2300820, upload-time = "2025-11-03T22:31:55.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ca/959088729de8e0eac8dd516e4fb8623d8d92bad539060fa85c9e94d418a5/libcst-1.8.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:16cfe0cfca5fd840e1fb2c30afb628b023d3085b30c3484a79b61eae9d6fe7ba", size = 2301201, upload-time = "2025-11-03T22:31:57.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4c/2a21a8c452436097dfe1da277f738c3517f3f728713f16d84b9a3d67ca8d/libcst-1.8.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:455f49a93aea4070132c30ebb6c07c2dea0ba6c1fde5ffde59fc45dbb9cfbe4b", size = 2408213, upload-time = "2025-11-03T22:31:59.221Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/26/8f7b671fad38a515bb20b038718fd2221ab658299119ac9bcec56c2ced27/libcst-1.8.6-cp310-cp310-win_amd64.whl", hash = "sha256:72cca15800ffc00ba25788e4626189fe0bc5fe2a0c1cb4294bce2e4df21cc073", size = 2119189, upload-time = "2025-11-03T22:32:00.696Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bf/ffb23a48e27001165cc5c81c5d9b3d6583b21b7f5449109e03a0020b060c/libcst-1.8.6-cp310-cp310-win_arm64.whl", hash = "sha256:6cad63e3a26556b020b634d25a8703b605c0e0b491426b3e6b9e12ed20f09100", size = 2001736, upload-time = "2025-11-03T22:32:02.986Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/15/95c2ecadc0fb4af8a7057ac2012a4c0ad5921b9ef1ace6c20006b56d3b5f/libcst-1.8.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3649a813660fbffd7bc24d3f810b1f75ac98bd40d9d6f56d1f0ee38579021073", size = 2211289, upload-time = "2025-11-03T22:32:04.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c3/7e1107acd5ed15cf60cc07c7bb64498a33042dc4821874aea3ec4942f3cd/libcst-1.8.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cbe17067055829607c5ba4afa46bfa4d0dd554c0b5a583546e690b7367a29b6", size = 2092927, upload-time = "2025-11-03T22:32:06.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ff/0d2be87f67e2841a4a37d35505e74b65991d30693295c46fc0380ace0454/libcst-1.8.6-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:59a7e388c57d21d63722018978a8ddba7b176e3a99bd34b9b84a576ed53f2978", size = 2237002, upload-time = "2025-11-03T22:32:07.559Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/8c4a1b35c7894ccd7d33eae01ac8967122f43da41325223181ca7e4738fe/libcst-1.8.6-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b6c1248cc62952a3a005792b10cdef2a4e130847be9c74f33a7d617486f7e532", size = 2301048, upload-time = "2025-11-03T22:32:08.869Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8b/d1aa811eacf936cccfb386ae0585aa530ea1221ccf528d67144e041f5915/libcst-1.8.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6421a930b028c5ef4a943b32a5a78b7f1bf15138214525a2088f11acbb7d3d64", size = 2300675, upload-time = "2025-11-03T22:32:10.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6b/7b65cd41f25a10c1fef2389ddc5c2b2cc23dc4d648083fa3e1aa7e0eeac2/libcst-1.8.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6d8b67874f2188399a71a71731e1ba2d1a2c3173b7565d1cc7ffb32e8fbaba5b", size = 2407934, upload-time = "2025-11-03T22:32:11.856Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/401cfff374bb3b785adfad78f05225225767ee190997176b2a9da9ed9460/libcst-1.8.6-cp311-cp311-win_amd64.whl", hash = "sha256:b0d8c364c44ae343937f474b2e492c1040df96d94530377c2f9263fb77096e4f", size = 2119247, upload-time = "2025-11-03T22:32:13.279Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/17/085f59eaa044b6ff6bc42148a5449df2b7f0ba567307de7782fe85c39ee2/libcst-1.8.6-cp311-cp311-win_arm64.whl", hash = "sha256:5dcaaebc835dfe5755bc85f9b186fb7e2895dda78e805e577fef1011d51d5a5c", size = 2001774, upload-time = "2025-11-03T22:32:14.647Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3c/93365c17da3d42b055a8edb0e1e99f1c60c776471db6c9b7f1ddf6a44b28/libcst-1.8.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0c13d5bd3d8414a129e9dccaf0e5785108a4441e9b266e1e5e9d1f82d1b943c9", size = 2206166, upload-time = "2025-11-03T22:32:16.012Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cb/7530940e6ac50c6dd6022349721074e19309eb6aa296e942ede2213c1a19/libcst-1.8.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f1472eeafd67cdb22544e59cf3bfc25d23dc94058a68cf41f6654ff4fcb92e09", size = 2083726, upload-time = "2025-11-03T22:32:17.312Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/cf/7e5eaa8c8f2c54913160671575351d129170db757bb5e4b7faffed022271/libcst-1.8.6-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:089c58e75cb142ec33738a1a4ea7760a28b40c078ab2fd26b270dac7d2633a4d", size = 2235755, upload-time = "2025-11-03T22:32:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/55/54/570ec2b0e9a3de0af9922e3bb1b69a5429beefbc753a7ea770a27ad308bd/libcst-1.8.6-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c9d7aeafb1b07d25a964b148c0dda9451efb47bbbf67756e16eeae65004b0eb5", size = 2301473, upload-time = "2025-11-03T22:32:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4c/163457d1717cd12181c421a4cca493454bcabd143fc7e53313bc6a4ad82a/libcst-1.8.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:207481197afd328aa91d02670c15b48d0256e676ce1ad4bafb6dc2b593cc58f1", size = 2298899, upload-time = "2025-11-03T22:32:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1d/317ddef3669883619ef3d3395ea583305f353ef4ad87d7a5ac1c39be38e3/libcst-1.8.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:375965f34cc6f09f5f809244d3ff9bd4f6cb6699f571121cebce53622e7e0b86", size = 2408239, upload-time = "2025-11-03T22:32:23.275Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a1/f47d8cccf74e212dd6044b9d6dbc223636508da99acff1d54786653196bc/libcst-1.8.6-cp312-cp312-win_amd64.whl", hash = "sha256:da95b38693b989eaa8d32e452e8261cfa77fe5babfef1d8d2ac25af8c4aa7e6d", size = 2119660, upload-time = "2025-11-03T22:32:24.822Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d0/dd313bf6a7942cdf951828f07ecc1a7695263f385065edc75ef3016a3cb5/libcst-1.8.6-cp312-cp312-win_arm64.whl", hash = "sha256:bff00e1c766658adbd09a175267f8b2f7616e5ee70ce45db3d7c4ce6d9f6bec7", size = 1999824, upload-time = "2025-11-03T22:32:26.131Z" },
+    { url = "https://files.pythonhosted.org/packages/90/01/723cd467ec267e712480c772aacc5aa73f82370c9665162fd12c41b0065b/libcst-1.8.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7445479ebe7d1aff0ee094ab5a1c7718e1ad78d33e3241e1a1ec65dcdbc22ffb", size = 2206386, upload-time = "2025-11-03T22:32:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/b944944f910f24c094f9b083f76f61e3985af5a376f5342a21e01e2d1a81/libcst-1.8.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fc3fef8a2c983e7abf5d633e1884c5dd6fa0dcb8f6e32035abd3d3803a3a196", size = 2083945, upload-time = "2025-11-03T22:32:28.847Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a1/bd1b2b2b7f153d82301cdaddba787f4a9fc781816df6bdb295ca5f88b7cf/libcst-1.8.6-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1a3a5e4ee870907aa85a4076c914ae69066715a2741b821d9bf16f9579de1105", size = 2235818, upload-time = "2025-11-03T22:32:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ab/f5433988acc3b4d188c4bb154e57837df9488cc9ab551267cdeabd3bb5e7/libcst-1.8.6-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6609291c41f7ad0bac570bfca5af8fea1f4a27987d30a1fa8b67fe5e67e6c78d", size = 2301289, upload-time = "2025-11-03T22:32:31.812Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/57/89f4ba7a6f1ac274eec9903a9e9174890d2198266eee8c00bc27eb45ecf7/libcst-1.8.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25eaeae6567091443b5374b4c7d33a33636a2d58f5eda02135e96fc6c8807786", size = 2299230, upload-time = "2025-11-03T22:32:33.242Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/0aa693bc24cce163a942df49d36bf47a7ed614a0cd5598eee2623bc31913/libcst-1.8.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04030ea4d39d69a65873b1d4d877def1c3951a7ada1824242539e399b8763d30", size = 2408519, upload-time = "2025-11-03T22:32:34.678Z" },
+    { url = "https://files.pythonhosted.org/packages/db/18/6dd055b5f15afa640fb3304b2ee9df8b7f72e79513814dbd0a78638f4a0e/libcst-1.8.6-cp313-cp313-win_amd64.whl", hash = "sha256:8066f1b70f21a2961e96bedf48649f27dfd5ea68be5cd1bed3742b047f14acde", size = 2119853, upload-time = "2025-11-03T22:32:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ed/5ddb2a22f0b0abdd6dcffa40621ada1feaf252a15e5b2733a0a85dfd0429/libcst-1.8.6-cp313-cp313-win_arm64.whl", hash = "sha256:c188d06b583900e662cd791a3f962a8c96d3dfc9b36ea315be39e0a4c4792ebf", size = 1999808, upload-time = "2025-11-03T22:32:38.1Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d3/72b2de2c40b97e1ef4a1a1db4e5e52163fc7e7740ffef3846d30bc0096b5/libcst-1.8.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c41c76e034a1094afed7057023b1d8967f968782433f7299cd170eaa01ec033e", size = 2190553, upload-time = "2025-11-03T22:32:39.819Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/983b7b210ccc3ad94a82db54230e92599c4a11b9cfc7ce3bc97c1d2df75c/libcst-1.8.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5432e785322aba3170352f6e72b32bea58d28abd141ac37cc9b0bf6b7c778f58", size = 2074717, upload-time = "2025-11-03T22:32:41.373Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f2/9e01678fedc772e09672ed99930de7355757035780d65d59266fcee212b8/libcst-1.8.6-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:85b7025795b796dea5284d290ff69de5089fc8e989b25d6f6f15b6800be7167f", size = 2225834, upload-time = "2025-11-03T22:32:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/0d/7bed847b5c8c365e9f1953da274edc87577042bee5a5af21fba63276e756/libcst-1.8.6-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:536567441182a62fb706e7aa954aca034827b19746832205953b2c725d254a93", size = 2287107, upload-time = "2025-11-03T22:32:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f0/7e51fa84ade26c518bfbe7e2e4758b56d86a114c72d60309ac0d350426c4/libcst-1.8.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f04d3672bde1704f383a19e8f8331521abdbc1ed13abb349325a02ac56e5012", size = 2288672, upload-time = "2025-11-03T22:32:45.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cd/15762659a3f5799d36aab1bc2b7e732672722e249d7800e3c5f943b41250/libcst-1.8.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f04febcd70e1e67917be7de513c8d4749d2e09206798558d7fe632134426ea4", size = 2392661, upload-time = "2025-11-03T22:32:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6b/b7f9246c323910fcbe021241500f82e357521495dcfe419004dbb272c7cb/libcst-1.8.6-cp313-cp313t-win_amd64.whl", hash = "sha256:1dc3b897c8b0f7323412da3f4ad12b16b909150efc42238e19cbf19b561cc330", size = 2105068, upload-time = "2025-11-03T22:32:49.145Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0b/4fd40607bc4807ec2b93b054594373d7fa3d31bb983789901afcb9bcebe9/libcst-1.8.6-cp313-cp313t-win_arm64.whl", hash = "sha256:44f38139fa95e488db0f8976f9c7ca39a64d6bc09f2eceef260aa1f6da6a2e42", size = 1985181, upload-time = "2025-11-03T22:32:50.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/60/4105441989e321f7ad0fd28ffccb83eb6aac0b7cfb0366dab855dcccfbe5/libcst-1.8.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:b188e626ce61de5ad1f95161b8557beb39253de4ec74fc9b1f25593324a0279c", size = 2204202, upload-time = "2025-11-03T22:32:52.311Z" },
+    { url = "https://files.pythonhosted.org/packages/67/2f/51a6f285c3a183e50cfe5269d4a533c21625aac2c8de5cdf2d41f079320d/libcst-1.8.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:87e74f7d7dfcba9efa91127081e22331d7c42515f0a0ac6e81d4cf2c3ed14661", size = 2083581, upload-time = "2025-11-03T22:32:54.269Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/921b1c19b638860af76cdb28bc81d430056592910b9478eea49e31a7f47a/libcst-1.8.6-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:3a926a4b42015ee24ddfc8ae940c97bd99483d286b315b3ce82f3bafd9f53474", size = 2236495, upload-time = "2025-11-03T22:32:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a8/b00592f9bede618cbb3df6ffe802fc65f1d1c03d48a10d353b108057d09c/libcst-1.8.6-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3f4fbb7f569e69fd9e89d9d9caa57ca42c577c28ed05062f96a8c207594e75b8", size = 2301466, upload-time = "2025-11-03T22:32:57.337Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/790d9002f31580fefd0aec2f373a0f5da99070e04c5e8b1c995d0104f303/libcst-1.8.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:08bd63a8ce674be431260649e70fca1d43f1554f1591eac657f403ff8ef82c7a", size = 2300264, upload-time = "2025-11-03T22:32:58.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/dc3f10e65bab461be5de57850d2910a02c24c3ddb0da28f0e6e4133c3487/libcst-1.8.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e00e275d4ba95d4963431ea3e409aa407566a74ee2bf309a402f84fc744abe47", size = 2408572, upload-time = "2025-11-03T22:33:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3b/35645157a7590891038b077db170d6dd04335cd2e82a63bdaa78c3297dfe/libcst-1.8.6-cp314-cp314-win_amd64.whl", hash = "sha256:fea5c7fa26556eedf277d4f72779c5ede45ac3018650721edd77fd37ccd4a2d4", size = 2193917, upload-time = "2025-11-03T22:33:02.354Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a2/1034a9ba7d3e82f2c2afaad84ba5180f601aed676d92b76325797ad60951/libcst-1.8.6-cp314-cp314-win_arm64.whl", hash = "sha256:bb9b4077bdf8857b2483879cbbf70f1073bc255b057ec5aac8a70d901bb838e9", size = 2078748, upload-time = "2025-11-03T22:33:03.707Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a1/30bc61e8719f721a5562f77695e6154e9092d1bdf467aa35d0806dcd6cea/libcst-1.8.6-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:55ec021a296960c92e5a33b8d93e8ad4182b0eab657021f45262510a58223de1", size = 2188980, upload-time = "2025-11-03T22:33:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/14/c660204532407c5628e3b615015a902ed2d0b884b77714a6bdbe73350910/libcst-1.8.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ba9ab2b012fbd53b36cafd8f4440a6b60e7e487cd8b87428e57336b7f38409a4", size = 2074828, upload-time = "2025-11-03T22:33:06.864Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e2/c497c354943dff644749f177ee9737b09ed811b8fc842b05709a40fe0d1b/libcst-1.8.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c0a0cc80aebd8aa15609dd4d330611cbc05e9b4216bcaeabba7189f99ef07c28", size = 2225568, upload-time = "2025-11-03T22:33:08.354Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/45999676d07bd6d0eefa28109b4f97124db114e92f9e108de42ba46a8028/libcst-1.8.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:42a4f68121e2e9c29f49c97f6154e8527cd31021809cc4a941c7270aa64f41aa", size = 2286523, upload-time = "2025-11-03T22:33:10.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6c/517d8bf57d9f811862f4125358caaf8cd3320a01291b3af08f7b50719db4/libcst-1.8.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a434c521fadaf9680788b50d5c21f4048fa85ed19d7d70bd40549fbaeeecab1", size = 2288044, upload-time = "2025-11-03T22:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ce/24d7d49478ffb61207f229239879845da40a374965874f5ee60f96b02ddb/libcst-1.8.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6a65f844d813ab4ef351443badffa0ae358f98821561d19e18b3190f59e71996", size = 2392605, upload-time = "2025-11-03T22:33:12.962Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c3/829092ead738b71e96a4e96896c96f276976e5a8a58b4473ed813d7c962b/libcst-1.8.6-cp314-cp314t-win_amd64.whl", hash = "sha256:bdb14bc4d4d83a57062fed2c5da93ecb426ff65b0dc02ddf3481040f5f074a82", size = 2181581, upload-time = "2025-11-03T22:33:14.514Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/5d6a790a02eb0d9d36c4aed4f41b277497e6178900b2fa29c35353aa45ed/libcst-1.8.6-cp314-cp314t-win_arm64.whl", hash = "sha256:819c8081e2948635cab60c603e1bbdceccdfe19104a242530ad38a36222cb88f", size = 2065000, upload-time = "2025-11-03T22:33:16.257Z" },
 ]
 
 [[package]]
@@ -1417,6 +1565,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "myst-parser"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1474,6 +1631,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -2042,6 +2208,45 @@ wheels = [
 ]
 
 [[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2106,6 +2311,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-ft"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/5a0d575de784f9a1f94e2b1288c6886f13f34185e13117ed530f32b6f8a8/pyyaml_ft-8.0.0.tar.gz", hash = "sha256:0c947dce03954c7b5d38869ed4878b2e6ff1d44b08a0d84dc83fdad205ae39ab", size = 141057, upload-time = "2025-06-10T15:32:15.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/ba/a067369fe61a2e57fb38732562927d5bae088c73cb9bb5438736a9555b29/pyyaml_ft-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8c1306282bc958bfda31237f900eb52c9bedf9b93a11f82e1aab004c9a5657a6", size = 187027, upload-time = "2025-06-10T15:31:48.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c5/a3d2020ce5ccfc6aede0d45bcb870298652ac0cf199f67714d250e0cdf39/pyyaml_ft-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30c5f1751625786c19de751e3130fc345ebcba6a86f6bddd6e1285342f4bbb69", size = 176146, upload-time = "2025-06-10T15:31:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/23a9739291086ca0d3189eac7cd92b4d00e9fdc77d722ab610c35f9a82ba/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa992481155ddda2e303fcc74c79c05eddcdbc907b888d3d9ce3ff3e2adcfb0", size = 746792, upload-time = "2025-06-10T15:31:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/e8825f4ff725b7e560d62a3609e31d735318068e1079539ebfde397ea03e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec6c92b4207004b62dfad1f0be321c9f04725e0f271c16247d8b39c3bf3ea42", size = 786772, upload-time = "2025-06-10T15:31:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/58a4dcae8854f2fdca9b28d9495298fd5571a50d8430b1c3033ec95d2d0e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b", size = 778723, upload-time = "2025-06-10T15:31:56.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/fed0da92b5d5d7340a082e3802d84c6dc9d5fa142954404c41a544c1cb92/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a7f332bc565817644cdb38ffe4739e44c3e18c55793f75dddb87630f03fc254", size = 758478, upload-time = "2025-06-10T15:31:58.314Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/69/ac02afe286275980ecb2dcdc0156617389b7e0c0a3fcdedf155c67be2b80/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d10175a746be65f6feb86224df5d6bc5c049ebf52b89a88cf1cd78af5a367a8", size = 799159, upload-time = "2025-06-10T15:31:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/c492a9da2e39abdff4c3094ec54acac9747743f36428281fb186a03fab76/pyyaml_ft-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:58e1015098cf8d8aec82f360789c16283b88ca670fe4275ef6c48c5e30b22a96", size = 158779, upload-time = "2025-06-10T15:32:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9b/41998df3298960d7c67653669f37710fa2d568a5fc933ea24a6df60acaf6/pyyaml_ft-8.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb", size = 191331, upload-time = "2025-06-10T15:32:02.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/16/2710c252ee04cbd74d9562ebba709e5a284faeb8ada88fcda548c9191b47/pyyaml_ft-8.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8d445bf6ea16bb93c37b42fdacfb2f94c8e92a79ba9e12768c96ecde867046d1", size = 182879, upload-time = "2025-06-10T15:32:04.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/40/ae8163519d937fa7bfa457b6f78439cc6831a7c2b170e4f612f7eda71815/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c56bb46b4fda34cbb92a9446a841da3982cdde6ea13de3fbd80db7eeeab8b49", size = 811277, upload-time = "2025-06-10T15:32:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/28d82dbff7f87b96f0eeac79b7d972a96b4980c1e445eb6a857ba91eda00/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dab0abb46eb1780da486f022dce034b952c8ae40753627b27a626d803926483b", size = 831650, upload-time = "2025-06-10T15:32:08.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/df/161c4566facac7d75a9e182295c223060373d4116dead9cc53a265de60b9/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd48d639cab5ca50ad957b6dd632c7dd3ac02a1abe0e8196a3c24a52f5db3f7a", size = 815755, upload-time = "2025-06-10T15:32:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
 name = "radon"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2156,6 +2385,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "roman"
+version = "5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/7c/3901b35ed856329bf98e84da8e5e0b4d899ea0027eee222f1be42a24ff3f/roman-5.2.tar.gz", hash = "sha256:275fe9f46290f7d0ffaea1c33251b92b8e463ace23660508ceef522e7587cb6f", size = 8185, upload-time = "2025-11-11T08:03:57.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/14/ea3cdd7276fcd731a9003fe4abeb6b395a38110ddff6a6a509f4ee00f741/roman-5.2-py3-none-any.whl", hash = "sha256:89d3b47400388806d06ff77ea77c79ab080bc127820dea6bf34e1f1c1b8e676e", size = 6041, upload-time = "2025-11-11T08:03:56.051Z" },
 ]
 
 [[package]]
@@ -2411,6 +2649,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2489,6 +2736,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
+]
+
+[[package]]
+name = "types-docutils"
+version = "0.22.3.20251115"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/d7/576ec24bf61a280f571e1f22284793adc321610b9bcfba1bf468cf7b334f/types_docutils-0.22.3.20251115.tar.gz", hash = "sha256:0f79ea6a7bd4d12d56c9f824a0090ffae0ea4204203eb0006392906850913e16", size = 56828, upload-time = "2025-11-15T02:59:57.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/01/61ac9eb38f1f978b47443dc6fd2e0a3b0f647c2da741ddad30771f1b2b6f/types_docutils-0.22.3.20251115-py3-none-any.whl", hash = "sha256:c6e53715b65395d00a75a3a8a74e352c669bc63959e65a207dffaa22f4a2ad6e", size = 91951, upload-time = "2025-11-15T02:59:56.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
BREAKING CHANGE: EventClient now requires a combined Events API URL instead of separate username/token values. Removed use_testbed from ClientConfig and replaced CB_USERNAME, CB_TOKEN, and CB_USE_TESTBED with CB_EVENTS_URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Client now initialized with a single events URL (includes username/token); `use_testbed` removed. Env var auth consolidated to `CB_EVENTS_URL`; CLI `--testbed` option removed.

* **Documentation**
  * Quickstart, configuration, error-handling, examples, and docs updated to the events-URL form and revised samples.

* **CI / Tooling**
  * CI and Make targets adjusted for live tests and docs formatting; live runs gated by `CB_RUN_LIVE_TESTS` and `CB_EVENTS_URL`.

* **Tests / Examples**
  * Tests and examples updated to use events-URL helpers and reflect the new auth/config pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MountainGod2/cb-events/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->