### PR TITLE
refactor(request): add auth retry options for 401/403 responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: [--strict]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.21
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,9 @@ config = ClientConfig(
     retry_backoff=1.0,  # Initial backoff (seconds)
     retry_factor=2.0,  # Backoff multiplier
     retry_max_delay=300.0,  # Max retry delay (seconds)
+    auth_retry_attempts=1,  # 401/403 attempts (1 means disabled)
+    auth_retry_delay=0.0,  # Fixed delay between auth retries
+    auth_retry_status_codes={401, 403},  # Auth statuses eligible for retry
 )
 
 client = EventClient(events_url, config=config)
@@ -40,8 +43,19 @@ config = ClientConfig(
 )
 ```
 
-Retries are attempted on `429`, `5xx`, and Cloudflare `521-524`. Retries are never
-attempted for `401` or `403`.
+Retries are attempted on `429`, `5xx`, and Cloudflare `521-524`.
+
+Authentication statuses can use a separate fixed-delay retry budget.
+By default `auth_retry_attempts=1`, which preserves fail-fast behavior for
+`401` and `403` (no retry).
+
+```python
+config = ClientConfig(
+    auth_retry_attempts=3,
+    auth_retry_delay=0.2,
+    auth_retry_status_codes={401, 403},
+)
+```
 
 ## Validation Mode
 

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -45,7 +45,10 @@ asyncio.run(main())
 Built-in retries are enabled by default.
 
 - Retried: `429`, `500`, `502`, `503`, `504`, `521-524`
-- Not retried: `401`, `403`, and other `4xx` statuses
+- Not retried by default: `401`, `403`, and other `4xx` statuses
+
+`401`/`403` retries can be enabled with `ClientConfig(auth_retry_attempts=...)`
+for short fixed-delay retry sequences.
 
 If needed, tune retry settings with `ClientConfig(retry_attempts=..., retry_backoff=...)`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,11 +148,9 @@ future-annotations = true
     "hardcoded-password-func-arg",
     "private-member-access",
     "TC",
-    "pytest-fixture-autouse",
 ]
 "tests/conftest.py" = ["D"]
 "tests/test_router.py" = ["unused-function-argument", "unused-async"]
-"**/conftest.py" = ["pytest-fixture-autouse"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ exclude-newer = "1 week"
 exclude-newer-package = { cb-events = false }
 environments = ["python_version>='3.10'"]
 fork-strategy = "requires-python"
-constraint-dependencies = ["setuptools>=83.0.0"]
+# constraint-dependencies = ["setuptools>=83.0.0"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/cb_events"]
 
@@ -128,31 +129,31 @@ indent-width = 4
 preview = true
 select = ["ALL"]
 ignore = [
-    "COM812", # Incompatible with ruff formatter
-    "CPY001",
+    "missing-trailing-comma",   # Incompatible with ruff formatter
+    "missing-copyright-notice",
 ]
 future-annotations = true
 
 [tool.ruff.lint.per-file-ignores]
-"examples/*" = ["RUF029", "TC", "DOC", "TRY400"]
+"examples/*" = ["unused-async", "TC", "DOC", "error-instead-of-exception"]
 "tests/*" = [
     "ANN",
-    "E501",
-    "FBT001",
-    "PLC2701",
-    "PLR0913",
-    "PLR0917",
-    "PLR2004",
-    "S101",
-    "S105",
-    "S106",
-    "SLF001",
+    "line-too-long",
+    "boolean-type-hint-positional-argument",
+    "import-private-name",
+    "too-many-arguments",
+    "too-many-positional-arguments",
+    "magic-value-comparison",
+    "assert",
+    "hardcoded-password-string",
+    "hardcoded-password-func-arg",
+    "private-member-access",
     "TC",
-    "RUF076",
+    "pytest-fixture-autouse",
 ]
 "tests/conftest.py" = ["D"]
-"tests/test_router.py" = ["ARG001", "RUF029"]
-"**/conftest.py" = ["RUF076"]
+"tests/test_router.py" = ["unused-function-argument", "unused-async"]
+"**/conftest.py" = ["pytest-fixture-autouse"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ exclude-newer = "1 week"
 exclude-newer-package = { cb-events = false }
 environments = ["python_version>='3.10'"]
 fork-strategy = "requires-python"
-# constraint-dependencies = ["setuptools>=83.0.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/cb_events"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 exclude-newer = "1 week"
-exclude-newer-package = { cb-events = false }
+exclude-newer-package = { cb-events = false, gitpython = false }
 environments = ["python_version>='3.10'"]
 fork-strategy = "requires-python"
 

--- a/src/cb_events/__init__.py
+++ b/src/cb_events/__init__.py
@@ -21,7 +21,7 @@ from ._exceptions import (
 from ._models import Event, EventType, Media, Message, RoomSubject, Tip, User
 from ._router import HandlerFunc, Router
 
-try:  # noqa: RUF067 # Version lookup at import time is intentional
+try:  # ruff: ignore[non-empty-init-module] # Version lookup at import time is intentional
     __version__: str = version("cb-events")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"

--- a/src/cb_events/_client.py
+++ b/src/cb_events/_client.py
@@ -136,7 +136,7 @@ def _parse_events_url(events_url: str) -> tuple[str, str, str]:
         raise AuthError(msg)
 
     parts = [part for part in parsed.path.split("/") if part]
-    if len(parts) != 3 or parts[0] != "events":  # noqa: PLR2004
+    if len(parts) != 3 or parts[0] != "events":  # ruff: ignore[magic-value-comparison]
         msg = "Events URL must match https://<host>/events/<username>/<token>/"
         raise AuthError(msg)
 
@@ -387,7 +387,7 @@ class EventClient:
 
         Note:
             Poll position is tracked with nextUrl between iterations.
-        """  # noqa: DOC502  # Called functions raise AuthError/EventsError on failure.
+        """  # ruff: ignore[docstring-extraneous-exception]  # Called functions raise AuthError/EventsError on failure.
         while True:
             events = await self._poll()
             for event in events:

--- a/src/cb_events/_client.py
+++ b/src/cb_events/_client.py
@@ -21,7 +21,7 @@ from ._parser import (
     ParserContext,
     process_response,
 )
-from ._request import perform_request_attempt, request_with_retry
+from ._request import AuthRetryOptions, perform_request_attempt, request_with_retry
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -205,6 +205,13 @@ class EventClient:
             max_rate=_DEFAULT_MAX_RATE,
             time_period=_DEFAULT_TIME_PERIOD,
         )
+        self._auth_retry_options: AuthRetryOptions = AuthRetryOptions(
+            status_codes=self.config.auth_retry_status_codes,
+            attempts=self.config.auth_retry_attempts,
+            delay=self.config.auth_retry_delay,
+            username=self.username,
+            logger=_logger,
+        )
 
     @override
     def __repr__(self) -> str:
@@ -288,6 +295,7 @@ class EventClient:
             rate_limiter=self._rate_limiter,
             url=url,
             retry_status_codes=_RETRY_STATUS_CODES,
+            auth_retry=self._auth_retry_options,
         )
 
     async def _request(self, url: str) -> tuple[int, str]:

--- a/src/cb_events/_config.py
+++ b/src/cb_events/_config.py
@@ -15,6 +15,12 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
+_ALLOWED_AUTH_RETRY_STATUS_CODES: frozenset[int] = frozenset({
+    HTTPStatus.UNAUTHORIZED.value,
+    HTTPStatus.FORBIDDEN.value,
+})
+
+
 class ClientConfig(BaseModel):
     """Immutable settings for EventClient.
 
@@ -69,4 +75,15 @@ class ClientConfig(BaseModel):
                 f"retry_backoff ({self.retry_backoff})."
             )
             raise ValueError(msg)
+
+        invalid_auth_codes = self.auth_retry_status_codes - _ALLOWED_AUTH_RETRY_STATUS_CODES
+        if invalid_auth_codes:
+            allowed = ", ".join(str(code) for code in sorted(_ALLOWED_AUTH_RETRY_STATUS_CODES))
+            invalid = ", ".join(str(code) for code in sorted(invalid_auth_codes))
+            msg = (
+                "auth_retry_status_codes may only include authentication statuses "
+                f"({allowed}); got: {invalid}."
+            )
+            raise ValueError(msg)
+
         return self

--- a/src/cb_events/_config.py
+++ b/src/cb_events/_config.py
@@ -6,6 +6,7 @@ validation behavior.
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import TYPE_CHECKING, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -39,6 +40,18 @@ class ClientConfig(BaseModel):
 
     retry_max_delay: float = Field(default=300.0, ge=0)
     """Maximum delay between retries in seconds."""
+
+    auth_retry_attempts: int = Field(default=1, ge=1)
+    """Total auth-status attempts before returning the final 401/403."""
+
+    auth_retry_delay: float = Field(default=0.0, ge=0)
+    """Fixed delay in seconds between auth-status retry attempts."""
+
+    auth_retry_status_codes: frozenset[int] = frozenset({
+        HTTPStatus.UNAUTHORIZED.value,
+        HTTPStatus.FORBIDDEN.value,
+    })
+    """HTTP status codes eligible for auth-status retry behavior."""
 
     @model_validator(mode="after")
     def validate_delays(self) -> Self:

--- a/src/cb_events/_exceptions.py
+++ b/src/cb_events/_exceptions.py
@@ -114,8 +114,8 @@ def build_http_error(
         return AuthError(message, status_code=status_code, response_text=response_text)
     if status_code == _RATE_LIMIT_STATUS_CODE:
         return RateLimitError(message, status_code=status_code, response_text=response_text)
-    if 400 <= status_code < 500:  # noqa: PLR2004
+    if 400 <= status_code < 500:  # ruff: ignore[magic-value-comparison]
         return ClientRequestError(message, status_code=status_code, response_text=response_text)
-    if 500 <= status_code < 600 or status_code in CF_SERVER_ERROR_CODES:  # noqa: PLR2004
+    if 500 <= status_code < 600 or status_code in CF_SERVER_ERROR_CODES:  # ruff: ignore[magic-value-comparison]
         return ServerError(message, status_code=status_code, response_text=response_text)
     return HttpStatusError(message, status_code=status_code, response_text=response_text)

--- a/src/cb_events/_models.py
+++ b/src/cb_events/_models.py
@@ -230,7 +230,7 @@ class Event(BaseEventModel):
     _room_subject: RoomSubject | None = PrivateAttr(default=None)
 
     @override
-    def model_post_init(self, context: object, /) -> None:  # noqa: ARG002
+    def model_post_init(self, context: object, /) -> None:  # ruff: ignore[unused-method-argument]
         """Parse and cache all typed sub-models after field initialisation.
 
         Called once by Pydantic during ``__init__`` and ``model_validate``.

--- a/src/cb_events/_parser.py
+++ b/src/cb_events/_parser.py
@@ -399,7 +399,7 @@ def process_response(
     Raises:
         AuthError: If authentication fails.
         HttpStatusError: If response status is non-200 and not a timeout redirect.
-    """  # noqa: DOC501, DOC502  # ruff wants the raised function listed, not the propagated error(s).
+    """  # ruff: ignore[docstring-missing-exception, docstring-extraneous-exception]  # ruff wants the raised function listed, not the propagated error(s).
     if status in AUTH_ERROR_STATUS_CODES:
         context.logger.warning(
             "Authentication failed for user %s (HTTP %d)",

--- a/src/cb_events/_request.py
+++ b/src/cb_events/_request.py
@@ -80,9 +80,19 @@ async def perform_request_attempt(
         Tuple of (HTTP status code, response text).
 
     Raises:
+        ValueError: If auth retry status codes overlap general retry statuses.
         _RetryableStatusError: If the response status should be retried.
     """
     options = auth_retry or AuthRetryOptions()
+    overlapping_codes = options.status_codes & retry_status_codes
+    if overlapping_codes:
+        overlapping = ", ".join(str(code) for code in sorted(overlapping_codes))
+        msg = (
+            "auth retry status codes overlap retry_status_codes "
+            f"({overlapping}); this would bypass auth retry handling."
+        )
+        raise ValueError(msg)
+
     status = 0
     text = ""
     attempts = max(options.attempts, 1)

--- a/src/cb_events/_request.py
+++ b/src/cb_events/_request.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NoReturn
 
 import stamina
@@ -29,12 +31,39 @@ class _RetryableStatusError(Exception):
         self.response_text: str = response_text
 
 
+@dataclass(frozen=True)
+class AuthRetryOptions:
+    """Small, fixed-delay retry budget for HTTP 401/403 responses.
+
+    Kept separate from the exponential-backoff retry used for network/5xx
+    failures: a persistently invalid token should still fail fast, but a
+    lone 401/403 can also be a transient edge/WAF hiccup, so a few quick
+    retries are attempted first.
+    """
+
+    status_codes: frozenset[int] = frozenset()
+    """HTTP statuses eligible for this retry budget (typically 401/403)."""
+
+    attempts: int = 1
+    """Total attempts before returning the auth-status response as final."""
+
+    delay: float = 0.0
+    """Fixed delay in seconds between auth-retry attempts."""
+
+    username: str = ""
+    """Username used for log context."""
+
+    logger: logging.Logger | None = field(default=None)
+    """Optional logger for per-attempt auth-retry warnings."""
+
+
 async def perform_request_attempt(
     *,
     session: ClientSession,
     rate_limiter: AsyncLimiter,
     url: str,
     retry_status_codes: frozenset[int],
+    auth_retry: AuthRetryOptions | None = None,
 ) -> tuple[int, str]:
     """Perform one HTTP request attempt and return status/body.
 
@@ -42,7 +71,10 @@ async def perform_request_attempt(
         session: Active HTTP client session.
         rate_limiter: Rate limiter applied before each request.
         url: Fully qualified endpoint URL.
-        retry_status_codes: HTTP statuses that should trigger a retry.
+        retry_status_codes: HTTP statuses that should trigger the caller's
+            exponential-backoff retry via ``_RetryableStatusError``.
+        auth_retry: Optional small fixed-delay retry budget for 401/403
+            responses. Defaults to no retry (single attempt).
 
     Returns:
         Tuple of (HTTP status code, response text).
@@ -50,14 +82,33 @@ async def perform_request_attempt(
     Raises:
         _RetryableStatusError: If the response status should be retried.
     """
-    await rate_limiter.acquire()
-    async with session.get(url, allow_redirects=False) as response:
-        status = response.status
-        text = await response.text()
+    options = auth_retry or AuthRetryOptions()
+    status = 0
+    text = ""
+    attempts = max(options.attempts, 1)
+    for attempt in range(1, attempts + 1):
+        await rate_limiter.acquire()
+        async with session.get(url, allow_redirects=False) as response:
+            status = response.status
+            text = await response.text()
 
-    if status in retry_status_codes:
-        msg = f"HTTP {status}"
-        raise _RetryableStatusError(msg, status_code=status, response_text=text)
+        if status in retry_status_codes:
+            msg = f"HTTP {status}"
+            raise _RetryableStatusError(msg, status_code=status, response_text=text)
+
+        if status not in options.status_codes or attempt >= attempts:
+            break
+
+        if options.logger is not None:
+            options.logger.warning(
+                "Auth check attempt %d/%d failed for user %s (HTTP %d). Retrying...",
+                attempt,
+                attempts,
+                options.username,
+                status,
+            )
+        if options.delay > 0:
+            await asyncio.sleep(options.delay)
 
     return status, text
 
@@ -82,7 +133,7 @@ def _raise_request_failure(
         ServerError: If the final attempt failed with a 5xx or Cloudflare error code.
         RateLimitError: If the final attempt failed with HTTP 429.
         ClientRequestError: If the final attempt failed with another 4xx.
-    """  # noqa: DOC501, DOC502  # ruff wants the raised function listed, not the propagated error(s).
+    """  # ruff: ignore[docstring-missing-exception, docstring-extraneous-exception]  # ruff wants the raised function listed, not the propagated error(s).
     logger.error(
         "Request failed after %d attempts for user %s",
         attempts_made,
@@ -167,7 +218,7 @@ async def request_with_retry(
                             attempts_made,
                             config.retry_attempts,
                             username,
-                            type(exc).__name__,
+                            str(exc) or type(exc).__name__,
                         )
                     raise
 

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -68,3 +68,9 @@ def test_allow_max_delay_equal_to_backoff() -> None:
 
     assert config.retry_backoff == pytest.approx(5.0)
     assert config.retry_max_delay == pytest.approx(5.0)
+
+
+def test_reject_non_auth_status_in_auth_retry_status_codes() -> None:
+    """Auth retry statuses should only allow 401/403."""
+    with pytest.raises(ValidationError, match=r"auth_retry_status_codes may only include"):
+        ClientConfig(auth_retry_status_codes=frozenset({401, 429}))

--- a/tests/client/test_request_retry.py
+++ b/tests/client/test_request_retry.py
@@ -7,6 +7,7 @@ import stamina
 from aioresponses import aioresponses
 
 from cb_events import ClientConfig, EventsError, EventType
+from cb_events._request import AuthRetryOptions, perform_request_attempt
 from tests.conftest import EventClientFactory
 from tests.helpers import make_event, make_response
 
@@ -87,3 +88,15 @@ async def test_retries_on_retry_status_codes_then_succeeds(
 
     assert len(events) == 1
     assert events[0].type == EventType.TIP
+
+
+async def test_perform_request_attempt_rejects_overlapping_auth_and_general_statuses() -> None:
+    """Overlapping auth/general retry statuses should be rejected explicitly."""
+    with pytest.raises(ValueError, match=r"overlap retry_status_codes"):
+        await perform_request_attempt(
+            session=None,  # type: ignore[arg-type]
+            rate_limiter=None,  # type: ignore[arg-type]
+            url="https://events.testbed.cb.dev/events",
+            retry_status_codes=frozenset({401}),
+            auth_retry=AuthRetryOptions(status_codes=frozenset({401}), attempts=2),
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -79,6 +79,31 @@ async def test_authentication_error_propagation(
             await client._poll()
 
 
+async def test_authentication_retry_sequence_then_success(
+    event_client_factory: EventClientFactory,
+    aioresponses_mock: aioresponses,
+    testbed_url_pattern: re.Pattern[str],
+) -> None:
+    """Configured auth retries should handle 401/403 blips before success."""
+    success_response = make_response([make_event(EventType.TIP, event_id="1")])
+    aioresponses_mock.get(testbed_url_pattern, status=401)
+    aioresponses_mock.get(testbed_url_pattern, status=403)
+    aioresponses_mock.get(testbed_url_pattern, payload=success_response)
+
+    config = ClientConfig(
+        auth_retry_attempts=3,
+        auth_retry_delay=0.0,
+        retry_attempts=1,
+        retry_backoff=0.0,
+    )
+
+    async with event_client_factory(config=config) as client:
+        events = await client._poll()
+
+    assert len(events) == 1
+    assert events[0].type == EventType.TIP
+
+
 def test_version_attribute() -> None:
     """Package should expose a ``__version__`` attribute matching metadata."""
     assert isinstance(__version__, str)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -104,6 +104,42 @@ async def test_authentication_retry_sequence_then_success(
     assert events[0].type == EventType.TIP
 
 
+async def test_authentication_retry_uses_configured_delay_between_auth_retries(
+    event_client_factory: EventClientFactory,
+    aioresponses_mock: aioresponses,
+    testbed_url_pattern: re.Pattern[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auth retry delay should be awaited for each 401/403 retry before success."""
+    success_response = make_response([make_event(EventType.TIP, event_id="1")])
+    aioresponses_mock.get(testbed_url_pattern, status=401)
+    aioresponses_mock.get(testbed_url_pattern, status=403)
+    aioresponses_mock.get(testbed_url_pattern, payload=success_response)
+
+    observed_delays: list[float] = []
+    original_sleep = asyncio.sleep
+
+    async def _fake_sleep(delay: float) -> None:
+        await original_sleep(0)
+        observed_delays.append(delay)
+
+    monkeypatch.setattr("cb_events._request.asyncio.sleep", _fake_sleep)
+
+    config = ClientConfig(
+        auth_retry_attempts=3,
+        auth_retry_delay=0.25,
+        retry_attempts=1,
+        retry_backoff=0.0,
+    )
+
+    async with event_client_factory(config=config) as client:
+        events = await client._poll()
+
+    assert observed_delays == [0.25, 0.25]
+    assert len(events) == 1
+    assert events[0].type == EventType.TIP
+
+
 def test_version_attribute() -> None:
     """Package should expose a ``__version__`` attribute matching metadata."""
     assert isinstance(__version__, str)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -154,7 +154,7 @@ def test_reject_non_async_handler_on_decorator(router: Router) -> None:
     """Registering a non-async handler with on() should raise TypeError."""
     with pytest.raises(TypeError, match="must be async"):
 
-        @router.on(EventType.TIP)  # type: ignore  # noqa: PGH003
+        @router.on(EventType.TIP)  # type: ignore  # ruff: ignore[blanket-type-ignore]
         def sync_handler(event: Event) -> None:
             pass
 
@@ -163,7 +163,7 @@ def test_reject_non_async_handler_on_any_decorator(router: Router) -> None:
     """Registering a non-async handler with on_any() should raise TypeError."""
     with pytest.raises(TypeError, match="must be async"):
 
-        @router.on_any()  # type: ignore  # noqa: PGH003
+        @router.on_any()  # type: ignore  # ruff: ignore[blanket-type-ignore]
         def sync_handler(event: Event) -> None:
             pass
 
@@ -172,7 +172,7 @@ def test_reject_non_async_handler_on_any_bare_decorator(router: Router) -> None:
     """Registering a non-async handler with on_any should raise TypeError."""
     with pytest.raises(TypeError, match="must be async"):
 
-        @router.on_any  # type: ignore  # noqa: PGH003
+        @router.on_any  # type: ignore  # ruff: ignore[blanket-type-ignore]
         def sync_handler(event: Event) -> None:
             pass
 
@@ -184,7 +184,7 @@ def test_reject_partial_sync_handler(router: Router) -> None:
         pass
 
     with pytest.raises(TypeError, match="must be async"):
-        router.on(EventType.TIP)(partial(sync_handler, flag=True))  # type: ignore  # noqa: PGH003
+        router.on(EventType.TIP)(partial(sync_handler, flag=True))  # type: ignore  # ruff: ignore[blanket-type-ignore]
 
 
 async def test_accept_partial_async_handler(router: Router) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
 cb-events = false
+gitpython = false
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -661,11 +662,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.30.3"
+version = "3.31.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/01/9256cbe36eb2a84501920adad7d0e86738ab0ad60e64f4f5c38d7dd94dc1/filelock-3.30.3.tar.gz", hash = "sha256:6575420cd497ed15fc43a7ac46c48f6b6371c733fc40cf5a4e216871397bc1e2", size = 177706, upload-time = "2026-07-17T15:17:45.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/9f/994e80905542b748eb5b9f36d71458f0aea51a7be0fcb52ad959787dc1b7/filelock-3.31.0.tar.gz", hash = "sha256:c188cbc4307c18894c5424fa73f97ea7fa127ddf62192487546da3a214d0a381", size = 180931, upload-time = "2026-07-18T05:53:29.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/20/b0d6da41a08b30faef4f20302f5d826a9d39073750cd9100b463eb840cf4/filelock-3.30.3-py3-none-any.whl", hash = "sha256:06e1c6d5e12277022172b7f8d090affe0e8f940f1a37ca45f548855ee51a6b86", size = 94544, upload-time = "2026-07-17T15:17:44.129Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4a/e213905d3b8ad3d35d14fc056b36134a274e7f6a1050e94428b5be10a94c/filelock-3.31.0-py3-none-any.whl", hash = "sha256:739b73e580fe88bb78d830aeddbc492519ece3d97ac8368de13a2032c61010c1", size = 96080, upload-time = "2026-07-18T05:53:27.732Z" },
 ]
 
 [[package]]
@@ -815,14 +816,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.52"
+version = "3.1.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/fd/df0bafa4eb5ea2f51e1adee9f7a94c8e62c5d180e65117045dfca3439c8a/gitpython-3.1.52.tar.gz", hash = "sha256:de0a8ad86274c6e75ae8b37dd055ba68f19818c813108642263227b20775b48e", size = 223726, upload-time = "2026-07-16T03:15:59.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/45/d45f94fa38b199862959cd7b5461a31f03746d75ef59363339fc0c394345/gitpython-3.1.56.tar.gz", hash = "sha256:127adf5c73f1a822e368301c4d5ffa5d305ce611eccab76f3336f9380a78ad0b", size = 229619, upload-time = "2026-07-25T07:41:43.179Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/90/04dff7c1e176bb1c3011ef1647393d368790da710d8dde1cdcfad301f45a/gitpython-3.1.52-py3-none-any.whl", hash = "sha256:79a36ee1f83523214a3f72d56cf1c4e490d577dc61af77e43dfe5862bd9da01a", size = 215366, upload-time = "2026-07-16T03:15:58.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/27/8b9b039c7f026d4af8954dbbdcc9f101f8d6901daa3a65b065d8f450c0bd/gitpython-3.1.56-py3-none-any.whl", hash = "sha256:bedffdc4bdd2e3cf21b328711a552b0529751f08bff6591339d18492291ad035", size = 216644, upload-time = "2026-07-25T07:41:41.737Z" },
 ]
 
 [[package]]
@@ -1399,11 +1400,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -15,9 +15,6 @@ exclude-newer-span = "P1W"
 [options.exclude-newer-package]
 cb-events = false
 
-[manifest]
-constraints = [{ name = "setuptools", specifier = ">=83.0.0" }]
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
@@ -664,11 +661,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.30.2"
+version = "3.30.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/f7/2165ef325da22d854b8f81ca4799395f2eb6afa55cdb52c7710f028b5336/filelock-3.30.2.tar.gz", hash = "sha256:1ea7c857465c897a4a6e64c1aace28ff6b83f5bc66c1c06ea148efa65bc2ec5d", size = 176823, upload-time = "2026-07-16T19:50:42.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/01/9256cbe36eb2a84501920adad7d0e86738ab0ad60e64f4f5c38d7dd94dc1/filelock-3.30.3.tar.gz", hash = "sha256:6575420cd497ed15fc43a7ac46c48f6b6371c733fc40cf5a4e216871397bc1e2", size = 177706, upload-time = "2026-07-17T15:17:45.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/df/05118016cad66cd0d7c9417b2d4fc245be35decc4c36810f3c8dbf729d88/filelock-3.30.2-py3-none-any.whl", hash = "sha256:a64b58f75048ec39589983e97f5117163f822261dcb6ba843e098f05aac9663f", size = 94092, upload-time = "2026-07-16T19:50:41.189Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/20/b0d6da41a08b30faef4f20302f5d826a9d39073750cd9100b463eb840cf4/filelock-3.30.3-py3-none-any.whl", hash = "sha256:06e1c6d5e12277022172b7f8d090affe0e8f940f1a37ca45f548855ee51a6b86", size = 94544, upload-time = "2026-07-17T15:17:44.129Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication-failure retry configuration (eligible `401`/`403` status codes, retry attempts, fixed delay, optional logging context).
  * Auth retries apply rate limiting per authentication retry attempt, separate from general retry/backoff.

* **Bug Fixes**
  * Improved retry warning formatting to include clearer exception details.

* **Documentation**
  * Expanded retry docs to explain enabling and configuring `401`/`403` auth retries.

* **Tests**
  * Added integration coverage for auth-retry success sequencing and delay timing.
  * Added validation tests for rejecting invalid auth status codes and overlapping retry settings.

* **Maintenance**
  * Updated lint/format and tooling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->