### PR TITLE
refactor(request): use logger.exception and drop explicit exc_info

### DIFF
--- a/src/cb_events/__init__.py
+++ b/src/cb_events/__init__.py
@@ -6,6 +6,7 @@ for typical integration code.
 
 from __future__ import annotations
 
+import logging
 from importlib.metadata import PackageNotFoundError, version
 
 from ._client import EventClient
@@ -25,6 +26,8 @@ try:  # ruff: ignore[non-empty-init-module] # Version lookup at import time is i
     __version__: str = version("cb-events")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())  # ruff:ignore[non-empty-init-module] # Configuration of handlers is the prerogative of end-users
 
 
 __all__ = [

--- a/src/cb_events/_request.py
+++ b/src/cb_events/_request.py
@@ -144,11 +144,10 @@ def _raise_request_failure(
         RateLimitError: If the final attempt failed with HTTP 429.
         ClientRequestError: If the final attempt failed with another 4xx.
     """  # ruff: ignore[docstring-missing-exception, docstring-extraneous-exception]  # ruff wants the raised function listed, not the propagated error(s).
-    logger.error(
+    logger.exception(  # ruff:ignore[log-exception-outside-except-handler]  # Only ever called within except clauses.
         "Request failed after %d attempts for user %s",
         attempts_made,
         username,
-        exc_info=original_exception,
     )
 
     attempt_label = "attempt" if attempts_made == 1 else "attempts"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -244,7 +244,7 @@ def test_event_property_validation_errors_logged(
     log_msg: str,
 ) -> None:
     """When event properties fail validation, they should return None."""
-    caplog.set_level(logging.WARNING, logger="cb_events.models")
+    caplog.set_level(logging.WARNING, logger="cb_events._models")
     event = Event.model_validate({
         "method": method,
         "id": event_id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when request retries are exhausted, including clearer exception details in logs.
  - Prevented unnecessary “no handler found” logging warnings for applications that use the package.
  - Updated validation logging coverage to reflect current logger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->